### PR TITLE
remove change of current working directory

### DIFF
--- a/forge.go
+++ b/forge.go
@@ -227,11 +227,6 @@ func downloadForgeModule(name string, version string) {
 			}
 
 			tarBallReader := tar.NewReader(fileReader)
-			if err = os.Chdir(config.ForgeCacheDir); err != nil {
-
-				fmt.Println("downloadForgeModule(): error while chdir to", config.ForgeCacheDir, err)
-				os.Exit(1)
-			}
 			for {
 				header, err := tarBallReader.Next()
 				if err != nil {
@@ -244,14 +239,15 @@ func downloadForgeModule(name string, version string) {
 
 				// get the individual filename and extract to the current directory
 				filename := header.Name
+				targetFilename := config.ForgeCacheDir + "/" + filename
 				//Debugf("downloadForgeModule(): Trying to extract file" + filename)
 
 				switch header.Typeflag {
 				case tar.TypeDir:
 					// handle directory
 					//fmt.Println("Creating directory :", filename)
-					//err = os.MkdirAll(filename, os.FileMode(header.Mode)) // or use 0755 if you prefer
-					err = os.MkdirAll(filename, os.FileMode(0755)) // or use 0755 if you prefer
+					//err = os.MkdirAll(targetFilename, os.FileMode(header.Mode)) // or use 0755 if you prefer
+					err = os.MkdirAll(targetFilename, os.FileMode(0755)) // or use 0755 if you prefer
 
 					if err != nil {
 						fmt.Println("downloadForgeModule(): error while MkdirAll()", filename, err)
@@ -261,7 +257,7 @@ func downloadForgeModule(name string, version string) {
 				case tar.TypeReg:
 					// handle normal file
 					//fmt.Println("Untarring :", filename)
-					writer, err := os.Create(filename)
+					writer, err := os.Create(targetFilename)
 
 					if err != nil {
 						fmt.Println("downloadForgeModule(): error while Create()", filename, err)
@@ -270,7 +266,7 @@ func downloadForgeModule(name string, version string) {
 
 					io.Copy(writer, tarBallReader)
 
-					err = os.Chmod(filename, os.FileMode(0644))
+					err = os.Chmod(targetFilename, os.FileMode(0644))
 
 					if err != nil {
 						fmt.Println("downloadForgeModule(): error while Chmod()", filename, err)


### PR DESCRIPTION
Changing the current working directory conflicts with puppetfile mode. As the working directory is not set back after all modules are downloaded, the `syncForgeToModuleDir()` function will move them to _cache_tmp_dir/$module_dir_, and not to _./$module_dir_ as expected.

Either the current working directory must be set back after the tar file is extracted, which proves to be rather complicated as all modules are processed asynchronously, and therefore could only be done in a place not related to the actual change of the working directory.

As it is better to not change the current working directory at all the operations for the extracted files and directories should include the absolute path for the target file, as implemented by this patch.

Not sure if this is the correct branch to submit the PR against, but it was the only one with the -docker flag, so I started my branch from this.