### PR TITLE
add -usemove param

### DIFF
--- a/forge.go
+++ b/forge.go
@@ -227,11 +227,6 @@ func downloadForgeModule(name string, version string) {
 			}
 
 			tarBallReader := tar.NewReader(fileReader)
-			if err = os.Chdir(config.ForgeCacheDir); err != nil {
-
-				fmt.Println("downloadForgeModule(): error while chdir to", config.ForgeCacheDir, err)
-				os.Exit(1)
-			}
 			for {
 				header, err := tarBallReader.Next()
 				if err != nil {
@@ -244,14 +239,15 @@ func downloadForgeModule(name string, version string) {
 
 				// get the individual filename and extract to the current directory
 				filename := header.Name
+				targetFilename := config.ForgeCacheDir + "/" + filename
 				//Debugf("downloadForgeModule(): Trying to extract file" + filename)
 
 				switch header.Typeflag {
 				case tar.TypeDir:
 					// handle directory
 					//fmt.Println("Creating directory :", filename)
-					//err = os.MkdirAll(filename, os.FileMode(header.Mode)) // or use 0755 if you prefer
-					err = os.MkdirAll(filename, os.FileMode(0755)) // or use 0755 if you prefer
+					//err = os.MkdirAll(targetFilename, os.FileMode(header.Mode)) // or use 0755 if you prefer
+					err = os.MkdirAll(targetFilename, os.FileMode(0755)) // or use 0755 if you prefer
 
 					if err != nil {
 						fmt.Println("downloadForgeModule(): error while MkdirAll()", filename, err)
@@ -261,7 +257,7 @@ func downloadForgeModule(name string, version string) {
 				case tar.TypeReg:
 					// handle normal file
 					//fmt.Println("Untarring :", filename)
-					writer, err := os.Create(filename)
+					writer, err := os.Create(targetFilename)
 
 					if err != nil {
 						fmt.Println("downloadForgeModule(): error while Create()", filename, err)
@@ -270,7 +266,7 @@ func downloadForgeModule(name string, version string) {
 
 					io.Copy(writer, tarBallReader)
 
-					err = os.Chmod(filename, os.FileMode(0644))
+					err = os.Chmod(targetFilename, os.FileMode(0644))
 
 					if err != nil {
 						fmt.Println("downloadForgeModule(): error while Chmod()", filename, err)
@@ -362,6 +358,9 @@ func syncForgeToModuleDir(name string, m ForgeModule, moduleDir string) {
 	} else {
 		Infof("Need to sync " + targetDir)
 		cmd := "cp --link --archive " + workDir + "* " + targetDir
+		if usemove {
+			cmd = "mv " + workDir + "* " + targetDir
+		}
 		before := time.Now()
 		out, err := exec.Command("bash", "-c", cmd).CombinedOutput()
 		duration := time.Since(before).Seconds()

--- a/g10k.go
+++ b/g10k.go
@@ -15,6 +15,7 @@ var (
 	verbose            bool
 	info               bool
 	force              bool
+	usemove            bool
 	pfMode             bool
 	config             ConfigSettings
 	wg                 sync.WaitGroup
@@ -92,6 +93,7 @@ func main() {
 		envBranchFlag = flag.String("branch", "", "which git branch of the Puppet environment to update, e.g. core_foobar")
 		pfFlag        = flag.Bool("puppetfile", false, "install all modules from Puppetfile in cwd")
 		forceFlag     = flag.Bool("force", false, "purge the Puppet environment directory and do a full sync")
+		usemoveFlag   = flag.Bool("usemove", false, "do not use hardlinks to populate your Puppet environments with Puppetlabs Forge modules. Uses simple move instead of hard links and purge the Forge cache directory after each run!")
 		debugFlag     = flag.Bool("debug", false, "log debug output, defaults to false")
 		verboseFlag   = flag.Bool("verbose", false, "log verbose output, defaults to false")
 		infoFlag      = flag.Bool("info", false, "log info output, defaults to false")
@@ -103,6 +105,7 @@ func main() {
 	verbose = *verboseFlag
 	info = *infoFlag
 	force = *forceFlag
+	usemove = *usemoveFlag
 	pfMode = *pfFlag
 
 	if *versionFlag {
@@ -132,7 +135,15 @@ func main() {
 			Debugf("Trying to use as Puppetfile: ./Puppetfile")
 			sm := make(map[string]Source)
 			sm["cmdlineparam"] = Source{Basedir: "."}
-			config = ConfigSettings{CacheDir: "/tmp/", ForgeCacheDir: "/tmp/", ModulesCacheDir: "/tmp/", EnvCacheDir: "/tmp/", Sources: sm}
+			cachedir := "/tmp/g10k"
+			if len(os.Getenv("g10k_cachedir")) > 0 {
+				cachedir = os.Getenv("g10k_cachedir")
+				cachedir = checkDirAndCreate(cachedir, "cachedir environment variable g10k_cachedir")
+				Debugf("Found environment variable g10k_cachedir set to: " + cachedir)
+			} else {
+				cachedir = checkDirAndCreate(cachedir, "cachedir default value")
+			}
+			config = ConfigSettings{CacheDir: cachedir, ForgeCacheDir: cachedir, ModulesCacheDir: cachedir, EnvCacheDir: cachedir, Sources: sm}
 			target = "./Puppetfile"
 			puppetfile := readPuppetfile("./Puppetfile", "")
 			pfm := make(map[string]Puppetfile)
@@ -144,6 +155,11 @@ func main() {
 			log.Printf("or: %s -puppetfile\n", os.Args[0])
 			os.Exit(1)
 		}
+	}
+
+	if usemove {
+		// we can not reuse the Forge cache at all when -usemove gets used, because we can not delete the -latest link for some reason
+		defer purgeDir(config.ForgeCacheDir, "main() -puppetfile mode with -usemove parameter")
 	}
 
 	before := time.Now()

--- a/helper.go
+++ b/helper.go
@@ -71,10 +71,24 @@ func createOrPurgeDir(dir string, callingFunction string) {
 	} else {
 		Debugf("createOrPurgeDir(): Trying to remove: " + dir + " called from " + callingFunction)
 		if err := os.RemoveAll(dir); err != nil {
-			log.Print("createOrPurgeDir(): error: removing dir failed", err)
+			log.Print("createOrPurgeDir(): error: removing dir failed: ", err)
 		}
 		Debugf("createOrPurgeDir(): Trying to create dir: " + dir + " called from " + callingFunction)
 		os.Mkdir(dir, 0777)
+	}
+}
+
+func purgeDir(dir string, callingFunction string) {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		Debugf("purgeDir(): Unnecessary to remove dir: " + dir + " it does not exist. Called from " + callingFunction)
+	} else {
+		Debugf("purgeDir(): Trying to remove: " + dir + " called from " + callingFunction)
+		if err := os.RemoveAll(dir); err != nil {
+			log.Print("purgeDir(): os.RemoveAll() error: removing dir failed: ", err)
+			if err = syscall.Unlink(dir); err != nil {
+				log.Print("purgeDir(): syscall.Unlink() error: removing link failed: ", err)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
This will use `mv` instead of hardlinks to populate the Puppet environment with Puppetlabs Forge modules.
This also means that the cachedir needs to get deleted afterwards.

Also added `cachedir` env variable to specify a different cachedir than
the default `/tmp/g10k/`
This fixes #10