### PR TITLE
add custom Forge base URL support in Puppetfile

### DIFF
--- a/config.go
+++ b/config.go
@@ -98,7 +98,8 @@ func readPuppetfile(pf string, sshKey string, source string) Puppetfile {
 
 	n := preparePuppetfile(pf)
 
-	reModuledir := regexp.MustCompile("^\\s*(?:moduledir)\\s*['\"]?([^'\"]+)['\"]")
+	reModuledir := regexp.MustCompile("^\\s*(?:moduledir)\\s*['\"]?([^'\"]+)['\"]?")
+	reForgeBaseURL := regexp.MustCompile("^\\s*(?:forge.baseUrl)\\s*['\"]?([^'\"]+)['\"]?")
 	reForgeModule := regexp.MustCompile("^\\s*(?:mod)\\s*['\"]?([^'\"]+/[^'\"]+)['\"](?:\\s*(,)\\s*['\"]?([^'\"]*))?")
 	reGitModule := regexp.MustCompile("^\\s*(?:mod)\\s*['\"]?([^'\"/]+)['\"]\\s*,(.*)")
 	reGitAttribute := regexp.MustCompile("\\s*:(git|commit|tag|branch|ref|link|ignore[-_]unreachable)\\s*=>\\s*['\"]?([^'\"]+)['\"]?")
@@ -113,6 +114,9 @@ func readPuppetfile(pf string, sshKey string, source string) Puppetfile {
 		}
 		if m := reModuledir.FindStringSubmatch(line); len(m) > 1 {
 			puppetFile.moduleDir = m[1]
+		} else if m := reForgeBaseURL.FindStringSubmatch(line); len(m) > 1 {
+			puppetFile.forgeBaseURL = m[1]
+			//fmt.Println("found forge base URL parameter ---> ", m[1])
 		} else if m := reForgeModule.FindStringSubmatch(line); len(m) > 1 {
 			//fmt.Println("found forge mod name ---> ", m[1])
 			comp := strings.Split(m[1], "/")

--- a/helper.go
+++ b/helper.go
@@ -20,20 +20,27 @@ func Debugf(s string) {
 	}
 }
 
-// Verbosef is a helper function for debug logging if global variable verbose is set to true
+// Verbosef is a helper function for verbose logging if global variable verbose is set to true
 func Verbosef(s string) {
 	if debug != false || verbose != false {
 		log.Print(fmt.Sprint(s))
 	}
 }
 
-// Infof is a helper function for debug logging if global variable info is set to true
+// Infof is a helper function for info logging if global variable info is set to true
 func Infof(s string) {
 	if debug != false || verbose != false || info != false {
 		color.Set(color.FgGreen)
 		fmt.Println(s)
 		color.Unset()
 	}
+}
+
+// Fatalf is a helper function for fatal logging
+func Fatalf(s string) {
+	color.Set(color.FgRed)
+	log.Fatal(s)
+	color.Unset()
 }
 
 // fileExists checks if the given file exists and return a bool
@@ -51,14 +58,12 @@ func checkDirAndCreate(dir string, name string) string {
 			if _, err := os.Stat(dir); os.IsNotExist(err) {
 				//log.Printf("checkDirAndCreate(): trying to create dir '%s' as %s", dir, name)
 				if err := os.MkdirAll(dir, 0777); err != nil {
-					log.Print("checkDirAndCreate(): Error: failed to create directory: ", dir)
-					os.Exit(1)
+					Fatalf("checkDirAndCreate(): Error: failed to create directory: " + dir)
 				}
 			}
 		} else {
 			// TODO make dir optional
-			log.Print("dir setting '" + name + "' missing! Exiting!")
-			os.Exit(1)
+			Fatalf("checkDirAndCreate(): Error: dir setting '" + name + "' missing! Exiting!")
 		}
 	}
 	if !strings.HasSuffix(dir, "/") {

--- a/puppetfile.go
+++ b/puppetfile.go
@@ -96,7 +96,7 @@ func resolvePuppetEnvironment(envBranch string) {
 func resolvePuppetfile(allPuppetfiles map[string]Puppetfile) {
 	var wg sync.WaitGroup
 	uniqueGitModules := make(map[string]GitModule)
-	uniqueForgeModules = make(map[string]struct{})
+	uniqueForgeModules = make(map[string]ForgeModule)
 	latestForgeModules = make(map[string]string)
 	exisitingModuleDirs := make(map[string]struct{})
 	for env, pf := range allPuppetfiles {
@@ -112,10 +112,15 @@ func resolvePuppetfile(allPuppetfiles map[string]Puppetfile) {
 		}
 		for forgeModuleName, fm := range pf.forgeModules {
 			//fmt.Println("Found Forge module ", forgeModuleName, " with version", fm.version)
+			if len(pf.forgeBaseURL) > 0 {
+				fm.baseUrl = pf.forgeBaseURL
+			} else {
+				fm.baseUrl = ""
+			}
 			mutex.Lock()
 			forgeModuleName = strings.Replace(forgeModuleName, "/", "-", -1)
 			if _, ok := uniqueForgeModules[forgeModuleName+"-"+fm.version]; !ok {
-				uniqueForgeModules[forgeModuleName+"-"+fm.version] = empty
+				uniqueForgeModules[forgeModuleName+"-"+fm.version] = fm
 			}
 			mutex.Unlock()
 		}


### PR DESCRIPTION
- replaced ugly regex parsing of the Forge JSON response with real JSON decoding
- adding meta information (like which Forge base URL should be used) about every Forge module to all functions