### PR TITLE
add force_forge_versions source parameter to g10k config

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,25 @@ Tip: You can see which branch was used, when using the `-verbose` parameter:
 Synced ./Puppetfile with 4 git repositories and 0 Forge modules in 1.1s with git (1.1s sync, I/O 0.0s) and Forge (0.0s query+download, I/O 0.0s)
 ```
 
+# additional g10k config features compared to r10k
+- you can enforce version numbers of Forge modules in your Puppetfiles instead of `:latest` or `:present` by adding `force_forge_versions: true` to the g10k config in the specific resource
+
+```
+---
+:cachedir: '/tmp/g10k'
+
+sources:
+  example:
+    remote: 'https://github.com/xorpaul/g10k-environment.git'
+    basedir: '/tmp/example/'
+    force_forge_versions: true
+```
+
+If g10k then encounters `:latest` or `:present` for a Forge module it errors out with:
+
+```
+2016/11/15 18:45:38 Error: Found present setting for forge module in /tmp/example/example_benchmark/Puppetfile for module puppetlabs/concat line: mod 'puppetlabs/concat' and force_forge_versions is set to true! Please specify a version (e.g. '2.3.0')
+```
 
 # building
 ```

--- a/g10k.go
+++ b/g10k.go
@@ -67,10 +67,11 @@ type Git struct {
 
 // Source contains basic information about a Puppet environment repository
 type Source struct {
-	Remote     string
-	Basedir    string
-	Prefix     string
-	PrivateKey string `yaml:"private_key"`
+	Remote             string
+	Basedir            string
+	Prefix             string
+	PrivateKey         string `yaml:"private_key"`
+	ForceForgeVersions bool   `yaml:"force_forge_versions"`
 }
 
 // Puppetfile contains the key value pairs from the Puppetfile
@@ -194,7 +195,7 @@ func main() {
 			forgeDefaultSettings := Forge{Baseurl: "https://forgeapi.puppetlabs.com"}
 			config = ConfigSettings{CacheDir: cachedir, ForgeCacheDir: cachedir, ModulesCacheDir: cachedir, EnvCacheDir: cachedir, Sources: sm, Forge: forgeDefaultSettings}
 			target = "./Puppetfile"
-			puppetfile := readPuppetfile("./Puppetfile", "", "cmdlineparam")
+			puppetfile := readPuppetfile("./Puppetfile", "", "cmdlineparam", false)
 			pfm := make(map[string]Puppetfile)
 			pfm["cmdlineparam"] = puppetfile
 			resolvePuppetfile(pfm)

--- a/g10k_puppetfile_test.go
+++ b/g10k_puppetfile_test.go
@@ -1,0 +1,461 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+func equalPuppetfile(a, b Puppetfile) bool {
+	if &a == &b {
+		return true
+	}
+	if a.moduleDir != b.moduleDir || a.forgeBaseURL != b.forgeBaseURL ||
+		a.forgeCacheTtl != b.forgeCacheTtl ||
+		a.privateKey != b.privateKey ||
+		a.source != b.source {
+		return false
+	}
+
+	if len(a.gitModules) != len(b.gitModules) ||
+		len(a.forgeModules) != len(b.forgeModules) {
+		return false
+	}
+
+	for gitModuleName, gm := range a.gitModules {
+		if _, ok := b.gitModules[gitModuleName]; !ok {
+			return false
+		}
+		if !equalGitModule(gm, b.gitModules[gitModuleName]) {
+			return false
+		}
+	}
+
+	for forgeModuleName, fm := range a.forgeModules {
+		if _, ok := b.forgeModules[forgeModuleName]; !ok {
+			return false
+		}
+		//fmt.Println("checking Forge module: ", forgeModuleName, fm)
+		if !equalForgeModule(fm, b.forgeModules[forgeModuleName]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func equalForgeModule(a, b ForgeModule) bool {
+	if &a == &b {
+		return true
+	}
+	if a.author != b.author || a.name != b.name ||
+		a.version != b.version ||
+		a.hashSum != b.hashSum ||
+		a.fileSize != b.fileSize ||
+		a.baseUrl != b.baseUrl ||
+		a.cacheTtl != b.cacheTtl {
+		return false
+	}
+	return true
+}
+
+func equalGitModule(a, b GitModule) bool {
+	if &a == &b {
+		return true
+	}
+	if a.git != b.git || a.link != b.link ||
+		a.privateKey != b.privateKey ||
+		a.branch != b.branch ||
+		a.tag != b.tag ||
+		a.commit != b.commit ||
+		a.ref != b.ref ||
+		a.link != b.link ||
+		a.ignoreUnreachable != b.ignoreUnreachable {
+		return false
+	}
+	if len(a.fallback) != len(b.fallback) {
+		return false
+	}
+	for i, v := range a.fallback {
+		if b.fallback[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func TestPreparePuppetfile(t *testing.T) {
+	t.Parallel()
+	expected := regexp.MustCompile("(moduledir 'external_modules'\nmod 'puppetlabs/ntp')")
+	got := preparePuppetfile("tests/TestPreparePuppetfile")
+
+	if !expected.MatchString(got) {
+		t.Error("Expected", expected, "got", got)
+	}
+}
+
+func TestCommentPuppetfile(t *testing.T) {
+	t.Parallel()
+	expected := regexp.MustCompile("mod 'sensu',\\s*:git => 'https://github.com/sensu/sensu-puppet.git',\\s*:commit => '8f4fc5780071c4895dec559eafc6030511b0caaa'")
+	got := preparePuppetfile("tests/TestCommentPuppetfile")
+
+	if !expected.MatchString(got) {
+		t.Error("Expected", expected, "got", got)
+	}
+}
+
+func TestReadPuppetfile(t *testing.T) {
+	t.Parallel()
+	funcName := strings.Split(funcName(), ".")[len(strings.Split(funcName(), "."))-1]
+	got := readPuppetfile("tests/"+funcName, "", "test", false)
+
+	fallbackMapExample := make([]string, 1)
+	fallbackMapExample[0] = "master"
+
+	fallbackMapExampleFull := make([]string, 3)
+	fallbackMapExampleFull[0] = "b"
+	fallbackMapExampleFull[1] = "a"
+	fallbackMapExampleFull[2] = "r"
+
+	fallbackMapAnother := make([]string, 4)
+	fallbackMapAnother[0] = "dev"
+	fallbackMapAnother[1] = "qa"
+	fallbackMapAnother[2] = "prelive"
+	fallbackMapAnother[3] = "live"
+
+	gm := make(map[string]GitModule)
+	gm["sensu"] = GitModule{git: "https://github.com/sensu/sensu-puppet.git",
+		commit: "8f4fc5780071c4895dec559eafc6030511b0caaa", ignoreUnreachable: false}
+	gm["example_module"] = GitModule{git: "git@somehost.com/foo/example-module.git",
+		link: true, ignoreUnreachable: false, fallback: fallbackMapExample}
+	gm["another_module"] = GitModule{git: "git@somehost.com/foo/another-module.git",
+		link: true, ignoreUnreachable: false, fallback: fallbackMapAnother}
+	gm["example_module_full"] = GitModule{git: "git@somehost.com/foo/example-module.git",
+		branch: "foo", ignoreUnreachable: true, fallback: fallbackMapExampleFull}
+
+	fm := make(map[string]ForgeModule)
+	fm["puppetlabs/apt"] = ForgeModule{version: "2.3.0", author: "puppetlabs", name: "apt"}
+	fm["puppetlabs/ntp"] = ForgeModule{version: "present", author: "puppetlabs", name: "ntp"}
+	fm["puppetlabs/stdlib"] = ForgeModule{version: "latest", author: "puppetlabs", name: "stdlib"}
+
+	expected := Puppetfile{moduleDir: "external_modules", gitModules: gm, forgeModules: fm, source: "test", forgeCacheTtl: time.Duration(50 * time.Minute), forgeBaseURL: "foobar"}
+
+	if !equalPuppetfile(got, expected) {
+		t.Error("Expected Puppetfile:", expected, ", but got Puppetfile:", got)
+	}
+}
+
+func TestFallbackPuppetfile(t *testing.T) {
+	t.Parallel()
+	fallbackMapExample := make([]string, 1)
+	fallbackMapExample[0] = "master"
+
+	fallbackMapAnother := make([]string, 4)
+	fallbackMapAnother[0] = "dev"
+	fallbackMapAnother[1] = "qa"
+	fallbackMapAnother[2] = "prelive"
+	fallbackMapAnother[3] = "live"
+
+	gm := make(map[string]GitModule)
+	gm["example_module"] = GitModule{git: "git@somehost.com/foo/example-module.git",
+		link: true, ignoreUnreachable: false, fallback: fallbackMapExample}
+	gm["another_module"] = GitModule{git: "git@somehost.com/foo/another-module.git",
+		branch: "master", ignoreUnreachable: false, fallback: fallbackMapAnother}
+
+	expected := Puppetfile{moduleDir: "modules", gitModules: gm, source: "test"}
+	got := readPuppetfile("tests/TestFallbackPuppetfile", "", "test", false)
+
+	if !equalGitModule(got.gitModules["example_module"], expected.gitModules["example_module"]) {
+		t.Error("Expected gitModules:", expected.gitModules["example_module"], ", but got gitModules:", got.gitModules["example_module"])
+	}
+
+	if !equalGitModule(got.gitModules["another_module"], expected.gitModules["another_module"]) {
+		t.Error("Expected gitModules:", expected.gitModules["another_module"], ", but got gitModules:", got.gitModules["another_module"])
+	}
+}
+
+func TestForgeCacheTtlPuppetfile(t *testing.T) {
+	t.Parallel()
+	expected := regexp.MustCompile("(moduledir 'external_modules'\nforge.cacheTtl 50m\n)")
+	got := preparePuppetfile("tests/TestForgeCacheTtlPuppetfile")
+
+	if !expected.MatchString(got) {
+		t.Error("Expected", expected, "got", got)
+	}
+
+	expectedPuppetfile := Puppetfile{moduleDir: "external_modules", forgeCacheTtl: 50 * time.Minute}
+	gotPuppetfile := readPuppetfile("tests/TestForgeCacheTtlPuppetfile", "", "test", false)
+
+	if gotPuppetfile.forgeCacheTtl != expectedPuppetfile.forgeCacheTtl {
+		t.Error("Expected for forgeCacheTtl", expectedPuppetfile.forgeCacheTtl, "got", gotPuppetfile.forgeCacheTtl)
+	}
+
+}
+
+func TestForceForgeVersionsPuppetfile(t *testing.T) {
+	t.Parallel()
+	funcName := strings.Split(funcName(), ".")[len(strings.Split(funcName(), "."))-1]
+	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
+		readPuppetfile("tests/"+funcName, "", "test", true)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run="+funcName+"$")
+	cmd.Env = append(os.Environ(), "TEST_FOR_CRASH_"+funcName+"=1")
+	err := cmd.Run()
+
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+	t.Errorf("readPuppetfile() terminated with %v, but we expected exit status 1", err)
+
+}
+
+func TestReadPuppetfileDuplicateGitAttribute(t *testing.T) {
+	t.Parallel()
+	funcName := strings.Split(funcName(), ".")[len(strings.Split(funcName(), "."))-1]
+	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
+		readPuppetfile("tests/"+funcName, "", "test", false)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run="+funcName+"$")
+	cmd.Env = append(os.Environ(), "TEST_FOR_CRASH_"+funcName+"=1")
+	err := cmd.Run()
+
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+	t.Errorf("readPuppetfile() terminated with %v, but we expected exit status 1", err)
+}
+
+func TestReadPuppetfileTrailingComma(t *testing.T) {
+	t.Parallel()
+	funcName := strings.Split(funcName(), ".")[len(strings.Split(funcName(), "."))-1]
+	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
+		readPuppetfile("tests/"+funcName, "", "test", false)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run="+funcName+"$")
+	cmd.Env = append(os.Environ(), "TEST_FOR_CRASH_"+funcName+"=1")
+	err := cmd.Run()
+
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+	t.Errorf("readPuppetfile() terminated with %v, but we expected exit status 1", err)
+
+}
+
+func TestReadPuppetfileInvalidForgeModuleName(t *testing.T) {
+	t.Parallel()
+	funcName := strings.Split(funcName(), ".")[len(strings.Split(funcName(), "."))-1]
+	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
+		readPuppetfile("tests/"+funcName, "", "test", false)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run="+funcName+"$")
+	cmd.Env = append(os.Environ(), "TEST_FOR_CRASH_"+funcName+"=1")
+	err := cmd.Run()
+
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+	t.Errorf("readPuppetfile() terminated with %v, but we expected exit status 1", err)
+
+}
+
+func TestReadPuppetfileDuplicateForgeModule(t *testing.T) {
+	t.Parallel()
+	funcName := strings.Split(funcName(), ".")[len(strings.Split(funcName(), "."))-1]
+	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
+		readPuppetfile("tests/"+funcName, "", "test", false)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run="+funcName+"$")
+	cmd.Env = append(os.Environ(), "TEST_FOR_CRASH_"+funcName+"=1")
+	err := cmd.Run()
+
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+	t.Errorf("readPuppetfile() terminated with %v, but we expected exit status 1", err)
+
+}
+
+func TestReadPuppetfileMissingGitAttribute(t *testing.T) {
+	t.Parallel()
+	funcName := strings.Split(funcName(), ".")[len(strings.Split(funcName(), "."))-1]
+	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
+		readPuppetfile("tests/"+funcName, "", "test", false)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run="+funcName+"$")
+	cmd.Env = append(os.Environ(), "TEST_FOR_CRASH_"+funcName+"=1")
+	err := cmd.Run()
+
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+	t.Errorf("readPuppetfile() terminated with %v, but we expected exit status 1", err)
+
+}
+
+func TestReadPuppetfileTooManyGitAttributes(t *testing.T) {
+	t.Parallel()
+	funcName := strings.Split(funcName(), ".")[len(strings.Split(funcName(), "."))-1]
+	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
+		readPuppetfile("tests/"+funcName, "", "test", false)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run="+funcName+"$")
+	cmd.Env = append(os.Environ(), "TEST_FOR_CRASH_"+funcName+"=1")
+	err := cmd.Run()
+
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+	t.Errorf("readPuppetfile() terminated with %v, but we expected exit status 1", err)
+
+}
+
+func TestReadPuppetfileConflictingGitAttributesTag(t *testing.T) {
+	t.Parallel()
+	funcName := strings.Split(funcName(), ".")[len(strings.Split(funcName(), "."))-1]
+	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
+		readPuppetfile("tests/"+funcName, "", "test", false)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run="+funcName+"$")
+	cmd.Env = append(os.Environ(), "TEST_FOR_CRASH_"+funcName+"=1")
+	err := cmd.Run()
+
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+	t.Errorf("readPuppetfile() terminated with %v, but we expected exit status 1", err)
+
+}
+
+func TestReadPuppetfileConflictingGitAttributesBranch(t *testing.T) {
+	t.Parallel()
+	funcName := strings.Split(funcName(), ".")[len(strings.Split(funcName(), "."))-1]
+	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
+		readPuppetfile("tests/"+funcName, "", "test", false)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run="+funcName+"$")
+	cmd.Env = append(os.Environ(), "TEST_FOR_CRASH_"+funcName+"=1")
+	err := cmd.Run()
+
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+	t.Errorf("readPuppetfile() terminated with %v, but we expected exit status 1", err)
+
+}
+
+func TestReadPuppetfileConflictingGitAttributesCommit(t *testing.T) {
+	t.Parallel()
+	funcName := strings.Split(funcName(), ".")[len(strings.Split(funcName(), "."))-1]
+	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
+		readPuppetfile("tests/"+funcName, "", "test", false)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run="+funcName+"$")
+	cmd.Env = append(os.Environ(), "TEST_FOR_CRASH_"+funcName+"=1")
+	err := cmd.Run()
+
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+	t.Errorf("readPuppetfile() terminated with %v, but we expected exit status 1", err)
+
+}
+
+func TestReadPuppetfileConflictingGitAttributesRef(t *testing.T) {
+	t.Parallel()
+	funcName := strings.Split(funcName(), ".")[len(strings.Split(funcName(), "."))-1]
+	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
+		readPuppetfile("tests/"+funcName, "", "test", false)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run="+funcName+"$")
+	cmd.Env = append(os.Environ(), "TEST_FOR_CRASH_"+funcName+"=1")
+	err := cmd.Run()
+
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+	t.Errorf("readPuppetfile() terminated with %v, but we expected exit status 1", err)
+
+}
+
+func TestReadPuppetfileIgnoreUnreachable(t *testing.T) {
+	t.Parallel()
+	funcName := strings.Split(funcName(), ".")[len(strings.Split(funcName(), "."))-1]
+	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
+		readPuppetfile("tests/"+funcName, "", "test", false)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run="+funcName+"$")
+	cmd.Env = append(os.Environ(), "TEST_FOR_CRASH_"+funcName+"=1")
+	err := cmd.Run()
+
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+	t.Errorf("readPuppetfile() terminated with %v, but we expected exit status 1", err)
+
+}
+
+func TestReadPuppetfileForgeCacheTtl(t *testing.T) {
+	t.Parallel()
+	funcName := strings.Split(funcName(), ".")[len(strings.Split(funcName(), "."))-1]
+	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
+		readPuppetfile("tests/"+funcName, "", "test", false)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run="+funcName+"$")
+	cmd.Env = append(os.Environ(), "TEST_FOR_CRASH_"+funcName+"=1")
+	err := cmd.Run()
+
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+	t.Errorf("readPuppetfile() terminated with %v, but we expected exit status 1", err)
+
+}
+
+func TestReadPuppetfileLink(t *testing.T) {
+	t.Parallel()
+	funcName := strings.Split(funcName(), ".")[len(strings.Split(funcName(), "."))-1]
+	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
+		readPuppetfile("tests/"+funcName, "", "test", false)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run="+funcName+"$")
+	cmd.Env = append(os.Environ(), "TEST_FOR_CRASH_"+funcName+"=1")
+	err := cmd.Run()
+
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+	t.Errorf("readPuppetfile() terminated with %v, but we expected exit status 1", err)
+
+}

--- a/g10k_puppetfile_test.go
+++ b/g10k_puppetfile_test.go
@@ -211,7 +211,24 @@ func TestForceForgeVersionsPuppetfile(t *testing.T) {
 		return
 	}
 	t.Errorf("readPuppetfile() terminated with %v, but we expected exit status 1", err)
+}
 
+func TestForceForgeVersionsPuppetfileCorrect(t *testing.T) {
+	t.Parallel()
+	funcName := strings.Split(funcName(), ".")[len(strings.Split(funcName(), "."))-1]
+	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
+		readPuppetfile("tests/"+funcName, "", "test", true)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run="+funcName+"$")
+	cmd.Env = append(os.Environ(), "TEST_FOR_CRASH_"+funcName+"=1")
+	err := cmd.Run()
+
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		t.Errorf("readPuppetfile() terminated with %v, but we expected exit status 0", err)
+	}
+	return
 }
 
 func TestReadPuppetfileDuplicateGitAttribute(t *testing.T) {

--- a/g10k_test.go
+++ b/g10k_test.go
@@ -2,55 +2,11 @@ package main
 
 import (
 	"reflect"
-	"regexp"
 	"testing"
-	"time"
 )
 
-func comparePuppetfile(a, b GitModule) bool {
-	if &a == &b {
-		return true
-	}
-	if a.git != b.git || a.link != b.link ||
-		a.privateKey != b.privateKey ||
-		a.branch != b.branch ||
-		a.tag != b.tag ||
-		a.commit != b.commit ||
-		a.ref != b.ref ||
-		a.link != b.link ||
-		a.ignoreUnreachable != b.ignoreUnreachable {
-		return false
-	}
-	if len(a.fallback) != len(b.fallback) {
-		return false
-	}
-	for i, v := range a.fallback {
-		if b.fallback[i] != v {
-			return false
-		}
-	}
-	return true
-}
-
-func TestPreparePuppetfile(t *testing.T) {
-	expected := regexp.MustCompile("(moduledir 'external_modules'\nmod 'puppetlabs/ntp')")
-	got := preparePuppetfile("tests/TestPreparePuppetfile")
-
-	if !expected.MatchString(got) {
-		t.Error("Expected", expected, "got", got)
-	}
-}
-
-func TestCommentPuppetfile(t *testing.T) {
-	expected := regexp.MustCompile("mod 'sensu',\\s+:git => 'https://github.com/sensu/sensu-puppet.git',\\s+:commit => '8f4fc5780071c4895dec559eafc6030511b0caaa'")
-	got := preparePuppetfile("tests/TestCommentPuppetfile")
-
-	if !expected.MatchString(got) {
-		t.Error("Expected", expected, "got", got)
-	}
-}
-
 func TestForgeChecksum(t *testing.T) {
+	t.Parallel()
 	expectedFmm := ForgeModule{hashSum: "8a8c741978e578921e489774f05e9a65", fileSize: 57358}
 	fmm := getMetadataForgeModule(ForgeModule{version: "2.2.0", name: "apt", author: "puppetlabs", baseUrl: "https://forgeapi.puppetlabs.com"})
 
@@ -63,24 +19,8 @@ func TestForgeChecksum(t *testing.T) {
 	}
 }
 
-func TestForgeCacheTtlPuppetfile(t *testing.T) {
-	expected := regexp.MustCompile("(moduledir 'external_modules'\nforge.cacheTtl 50m\n)")
-	got := preparePuppetfile("tests/TestForgeCacheTtlPuppetfile")
-
-	if !expected.MatchString(got) {
-		t.Error("Expected", expected, "got", got)
-	}
-
-	expectedPuppetfile := Puppetfile{moduleDir: "external_modules", forgeCacheTtl: 50 * time.Minute}
-	gotPuppetfile := readPuppetfile("tests/TestForgeCacheTtlPuppetfile", "", "test")
-
-	if gotPuppetfile.forgeCacheTtl != expectedPuppetfile.forgeCacheTtl {
-		t.Error("Expected for forgeCacheTtl", expectedPuppetfile.forgeCacheTtl, "got", gotPuppetfile.forgeCacheTtl)
-	}
-
-}
-
 func TestConfigPrefix(t *testing.T) {
+	t.Parallel()
 	got := readConfigfile("tests/TestConfigPrefix.yaml")
 
 	s := make(map[string]Source)
@@ -99,31 +39,22 @@ func TestConfigPrefix(t *testing.T) {
 	}
 }
 
-func TestFallbackPuppetfile(t *testing.T) {
-	fallbackMapExample := make([]string, 1)
-	fallbackMapExample[0] = "master"
+func TestConfigForceForgeVersions(t *testing.T) {
+	t.Parallel()
+	got := readConfigfile("tests/TestConfigForceForgeVersions.yaml")
 
-	fallbackMapAnother := make([]string, 4)
-	fallbackMapAnother[0] = "dev"
-	fallbackMapAnother[1] = "qa"
-	fallbackMapAnother[2] = "prelive"
-	fallbackMapAnother[3] = "live"
+	s := make(map[string]Source)
+	s["example"] = Source{Remote: "https://github.com/xorpaul/g10k-environment.git",
+		Basedir: "/tmp/example/", Prefix: "foobar", PrivateKey: "", ForceForgeVersions: true}
 
-	gm := make(map[string]GitModule)
-	gm["example_module"] = GitModule{git: "git@somehost.com/foo/example-module.git",
-		link: true, ignoreUnreachable: false, fallback: fallbackMapExample}
-	gm["another_module"] = GitModule{git: "git@somehost.com/foo/another-module.git",
-		link: true, ignoreUnreachable: false, fallback: fallbackMapAnother}
+	expected := ConfigSettings{
+		CacheDir: "/tmp/g10k/", ForgeCacheDir: "/tmp/g10k/forge/",
+		ModulesCacheDir: "/tmp/g10k/modules/", EnvCacheDir: "/tmp/g10k/environments/",
+		Git:     Git{privateKey: "", username: ""},
+		Forge:   Forge{Baseurl: "https://forgeapi.puppetlabs.com"},
+		Sources: s, Timeout: 5}
 
-	expected := Puppetfile{moduleDir: "modules", gitModules: gm, source: "test"}
-	got := readPuppetfile("tests/TestFallbackPuppetfile", "", "test")
-
-	if !comparePuppetfile(got.gitModules["example_module"], expected.gitModules["example_module"]) {
-		t.Error("Expected gitModules:", expected.gitModules["example_module"], ", but got gitModules:", got.gitModules["example_module"])
+	if !reflect.DeepEqual(got, expected) {
+		t.Error("Expected ConfigSettings:", expected, ", but got ConfigSettings:", got)
 	}
-
-	if !comparePuppetfile(got.gitModules["another_module"], expected.gitModules["another_module"]) {
-		t.Error("Expected gitModules:", expected.gitModules["another_module"], ", but got gitModules:", got.gitModules["another_module"])
-	}
-
 }

--- a/helper.go
+++ b/helper.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -148,4 +149,10 @@ func executeCommand(command string, timeout int, allowFail bool) ExecResult {
 		}
 	}
 	return er
+}
+
+// funcName return the function name as a string
+func funcName() string {
+	pc, _, _, _ := runtime.Caller(1)
+	return runtime.FuncForPC(pc).Name()
 }

--- a/puppetfile.go
+++ b/puppetfile.go
@@ -64,7 +64,7 @@ func resolvePuppetEnvironment(envBranch string) {
 							if !fileExists(targetDir + "Puppetfile") {
 								Debugf("Skipping branch " + source + "_" + branch + " because " + targetDir + "Puppetfile does not exitst")
 							} else {
-								puppetfile := readPuppetfile(targetDir+"Puppetfile", sa.PrivateKey, source)
+								puppetfile := readPuppetfile(targetDir+"Puppetfile", sa.PrivateKey, source, sa.ForceForgeVersions)
 								mutex.Lock()
 								allPuppetfiles[source+"_"+branch] = puppetfile
 								mutex.Unlock()
@@ -189,22 +189,23 @@ func resolvePuppetfile(allPuppetfiles map[string]Puppetfile) {
 				}
 				success := false
 				//fmt.Println(gitModule.fallback)
+				moduleCacheDir := config.ModulesCacheDir + strings.Replace(strings.Replace(gitModule.git, "/", "_", -1), ":", "-", -1)
 				if len(gitModule.fallback) > 0 {
-					success = syncToModuleDir(config.ModulesCacheDir+strings.Replace(strings.Replace(gitModule.git, "/", "_", -1), ":", "-", -1), targetDir, tree, true, gitModule.ignoreUnreachable)
+					success = syncToModuleDir(moduleCacheDir, targetDir, tree, true, gitModule.ignoreUnreachable)
 					if !success {
 						for i, fallbackBranch := range gitModule.fallback {
 							if i == len(gitModule.fallback)-1 {
 								// last try
 								gitModule.ignoreUnreachable = true
 							}
-							success = syncToModuleDir(config.ModulesCacheDir+strings.Replace(strings.Replace(gitModule.git, "/", "_", -1), ":", "-", -1), targetDir, fallbackBranch, true, gitModule.ignoreUnreachable)
+							success = syncToModuleDir(moduleCacheDir, targetDir, fallbackBranch, true, gitModule.ignoreUnreachable)
 							if success {
 								break
 							}
 						}
 					}
 				} else {
-					success = syncToModuleDir(config.ModulesCacheDir+strings.Replace(strings.Replace(gitModule.git, "/", "_", -1), ":", "-", -1), targetDir, tree, gitModule.ignoreUnreachable, gitModule.ignoreUnreachable)
+					success = syncToModuleDir(moduleCacheDir, targetDir, tree, gitModule.ignoreUnreachable, gitModule.ignoreUnreachable)
 				}
 
 				// remove this module from the exisitingModuleDirs map

--- a/test.yaml
+++ b/test.yaml
@@ -6,3 +6,4 @@ sources:
     remote: 'https://github.com/xorpaul/g10k-environment.git'
     basedir: '/tmp/example/'
     prefix: true
+    force_forge_versions: true

--- a/tests/TestConfigForceForgeVersions.yaml
+++ b/tests/TestConfigForceForgeVersions.yaml
@@ -1,0 +1,9 @@
+---
+:cachedir: '/tmp/g10k'
+
+sources:
+  example:
+    remote: 'https://github.com/xorpaul/g10k-environment.git'
+    basedir: '/tmp/example/'
+    force_forge_versions: true
+    prefix: foobar

--- a/tests/TestFallbackPuppetfile
+++ b/tests/TestFallbackPuppetfile
@@ -4,5 +4,5 @@ mod 'example_module',
     :fallback => 'master'
 mod 'another_module',
     :git => 'git@somehost.com/foo/another-module.git',
-    :link => true,
+    :branch => 'master',
     :fallback => 'dev|qa |prelive| live'

--- a/tests/TestForceForgeVersionsPuppetfile
+++ b/tests/TestForceForgeVersionsPuppetfile
@@ -1,0 +1,4 @@
+moduledir 'external_modules'
+
+#mod 'puppetlabs/apt', '2.3.0'
+mod 'puppetlabs/apt'

--- a/tests/TestForceForgeVersionsPuppetfileCorrect
+++ b/tests/TestForceForgeVersionsPuppetfileCorrect
@@ -1,0 +1,3 @@
+moduledir 'external_modules'
+
+mod 'puppetlabs/apt', '2.3.0'

--- a/tests/TestReadPuppetfile
+++ b/tests/TestReadPuppetfile
@@ -1,0 +1,30 @@
+mod 'sensu', # Puppet 4 supported
+     :git => 'https://github.com/sensu/sensu-puppet.git',
+     :commit => '8f4fc5780071c4895dec559eafc6030511b0caaa'
+mod 'example_module',
+    :git => 'git@somehost.com/foo/example-module.git',
+    :link => true,
+    :fallback => 'master'
+mod 'another_module',
+    :git => 'git@somehost.com/foo/another-module.git',
+    :link => true,
+    :fallback => 'dev|qa |prelive| live'
+moduledir 'external_modules'
+
+#mod 'puppetlabs/apt', '2.3.0'
+mod 'puppetlabs/apt', '2.3.0'
+forge.cacheTtl 50m
+moduledir 'external_modules'
+
+mod 'puppetlabs/ntp'
+
+
+  # comment
+mod 'example_module_full',
+  :git => 'git@somehost.com/foo/example-module.git',
+  :branch => 'foo',
+  :fallback => 'b | a| r',
+  :ignore-unreachable => true
+forge.baseUrl foobar
+mod 'puppetlabs/stdlib',
+  :latest

--- a/tests/TestReadPuppetfileConflictingGitAttributesBranch
+++ b/tests/TestReadPuppetfileConflictingGitAttributesBranch
@@ -1,0 +1,5 @@
+mod 'example_module',
+  :git => 'git@somehost.com/foo/example-module.git',
+  :branch => 'foo',
+  :link => true
+

--- a/tests/TestReadPuppetfileConflictingGitAttributesCommit
+++ b/tests/TestReadPuppetfileConflictingGitAttributesCommit
@@ -1,0 +1,5 @@
+mod 'example_module',
+  :git => 'git@somehost.com/foo/example-module.git',
+  :branch => 'foo',
+  :commit => 'bar'
+

--- a/tests/TestReadPuppetfileConflictingGitAttributesLink
+++ b/tests/TestReadPuppetfileConflictingGitAttributesLink
@@ -1,0 +1,5 @@
+mod 'example_module',
+  :git => 'git@somehost.com/foo/example-module.git',
+  :branch => 'foo',
+  :link => true
+

--- a/tests/TestReadPuppetfileConflictingGitAttributesRef
+++ b/tests/TestReadPuppetfileConflictingGitAttributesRef
@@ -1,0 +1,5 @@
+mod 'example_module',
+  :git => 'git@somehost.com/foo/example-module.git',
+  :branch => 'foo',
+  :ref => 'bar'
+

--- a/tests/TestReadPuppetfileConflictingGitAttributesTag
+++ b/tests/TestReadPuppetfileConflictingGitAttributesTag
@@ -1,0 +1,5 @@
+mod 'example_module',
+  :git => 'git@somehost.com/foo/example-module.git',
+  :branch => 'foo',
+  :tag => 'bar'
+

--- a/tests/TestReadPuppetfileDuplicateForgeModule
+++ b/tests/TestReadPuppetfileDuplicateForgeModule
@@ -1,0 +1,2 @@
+mod 'foo/bar', :latest
+mod 'foo/bar'

--- a/tests/TestReadPuppetfileDuplicateGitAttribute
+++ b/tests/TestReadPuppetfileDuplicateGitAttribute
@@ -1,0 +1,3 @@
+mod 'example_module',
+  :git => 'git@somehost.com/foo/example-module.git',
+  :git => 'git@somehost.com/foo/example-module.git'

--- a/tests/TestReadPuppetfileForgeCacheTtl
+++ b/tests/TestReadPuppetfileForgeCacheTtl
@@ -1,0 +1,6 @@
+forge.cacheTtl 300x
+mod 'example_module',
+  :git => 'git@somehost.com/foo/example-module.git',
+  :branch => 'foo',
+  :link => true
+

--- a/tests/TestReadPuppetfileIgnoreUnreachable
+++ b/tests/TestReadPuppetfileIgnoreUnreachable
@@ -1,0 +1,5 @@
+mod 'example_module',
+  :git => 'git@somehost.com/foo/example-module.git',
+  :branch => 'foo',
+  :ignore_unreachable => foo
+

--- a/tests/TestReadPuppetfileIncompatibleGitAttributesTag
+++ b/tests/TestReadPuppetfileIncompatibleGitAttributesTag
@@ -1,0 +1,6 @@
+moduledir 'external_modules'
+
+mod 'puppetlabs-stdlib',
+    :git => 'https://github.com/puppetlabs/puppetlabs-stdlib.git',
+    :branch => 'master',
+    :tag => '4.3.x'

--- a/tests/TestReadPuppetfileInvalidForgeModuleName
+++ b/tests/TestReadPuppetfileInvalidForgeModuleName
@@ -1,0 +1,1 @@
+mod 'foo/bar/example_module'

--- a/tests/TestReadPuppetfileLink
+++ b/tests/TestReadPuppetfileLink
@@ -1,5 +1,0 @@
-mod 'example_module',
-  :git => 'git@somehost.com/foo/example-module.git',
-  :branch => 'foo',
-  :link => rue
-

--- a/tests/TestReadPuppetfileLink
+++ b/tests/TestReadPuppetfileLink
@@ -1,0 +1,5 @@
+mod 'example_module',
+  :git => 'git@somehost.com/foo/example-module.git',
+  :branch => 'foo',
+  :link => rue
+

--- a/tests/TestReadPuppetfileMissingGitAttribute
+++ b/tests/TestReadPuppetfileMissingGitAttribute
@@ -1,0 +1,2 @@
+mod 'example_module',
+  :branch => 'foobar'

--- a/tests/TestReadPuppetfileTooManyGitAttributes
+++ b/tests/TestReadPuppetfileTooManyGitAttributes
@@ -1,0 +1,7 @@
+mod 'example_module',
+  :git => 'git@somehost.com/foo/example-module.git',
+  :branch => 'foo',
+  :fallback => 'b | a| r|',
+  :ignore-unreachable => true,
+  :link => true
+

--- a/tests/TestReadPuppetfileTrailingComma
+++ b/tests/TestReadPuppetfileTrailingComma
@@ -1,0 +1,3 @@
+mod 'example_module',
+  :git => 'git@somehost.com/foo/example-module.git',
+  :branch => 'foo',


### PR DESCRIPTION
you can enforce version numbers of Forge modules in your Puppetfiles instead of `:latest` or `:present` by adding `force_forge_versions: true` to the g10k config in the specific resource

```
---
:cachedir: '/tmp/g10k'

sources:
  example:
    remote: 'https://github.com/xorpaul/g10k-environment.git'
    basedir: '/tmp/example/'
    force_forge_versions: true
```

If g10k then encounters `:latest` or `:present` for a Forge module it errors out with:


>2016/11/15 18:45:38 Error: Found present setting for forge module in /tmp/example/example_benchmark/Puppetfile for module puppetlabs/concat line: mod 'puppetlabs/concat' and force_forge_versions is set to true! Please specify a version (e.g. '2.3.0')

