### PR TITLE
Fix remote arbitrary code execution

### DIFF
--- a/git.go
+++ b/git.go
@@ -104,7 +104,7 @@ func syncToModuleDir(srcDir string, targetDir string, tree string, allowFail boo
 		mutex.Unlock()
 		if !dryRun {
 			createOrPurgeDir(targetDir, "syncToModuleDir()")
-			cmd := "git --git-dir " + srcDir + " archive " + tree + " | tar -x -C " + targetDir
+			cmd := "git --git-dir " + srcDir + " archive '" + tree + "' | tar -x -C " + targetDir
 			before := time.Now()
 			out, err := exec.Command("bash", "-c", cmd).CombinedOutput()
 			duration := time.Since(before).Seconds()


### PR DESCRIPTION
The execution in a subshell and not quoting the branch name results in arbitrary remote code execution being possible.

Steps to reproduce:
* Push a branch with a name with shell code: `git checkout -b 'master;whoami' && git push -u origin`
* Synchronize or wait for synchronization

If an interface to g10k is available no push is needed in the first place, the code can be pushed directly.

Fix is quoting the branch for the subshell to prevent interpretation by the shell.