### PR TITLE
Determine existing ref with rev-parse instead of log

### DIFF
--- a/git.go
+++ b/git.go
@@ -77,7 +77,7 @@ func syncToModuleDir(srcDir string, targetDir string, tree string, allowFail boo
 	mutex.Lock()
 	syncGitCount++
 	mutex.Unlock()
-	logCmd := "git --git-dir " + srcDir + " log -n1 --pretty=format:%H " + tree
+	logCmd := "git --git-dir " + srcDir + " rev-parse '" + tree + "'"
 	er := executeCommand(logCmd, config.Timeout, allowFail)
 	hashFile := targetDir + "/.latest_commit"
 	needToSync := true

--- a/git.go
+++ b/git.go
@@ -77,7 +77,7 @@ func syncToModuleDir(srcDir string, targetDir string, tree string, allowFail boo
 	mutex.Lock()
 	syncGitCount++
 	mutex.Unlock()
-	logCmd := "git --git-dir " + srcDir + " rev-parse '" + tree + "'"
+	logCmd := "git --git-dir " + srcDir + " rev-parse --verify '" + tree + "'"
 	er := executeCommand(logCmd, config.Timeout, allowFail)
 	hashFile := targetDir + "/.latest_commit"
 	needToSync := true


### PR DESCRIPTION
Log fails under weird circumstances and causes empty directories for
modules without the branch, even though ignore-unreachable is set.

@xorpaul  You fixed that before, but it wasn't pushed to github.