### PR TITLE
Check target file before attempting to hardlink it

### DIFF
--- a/forge.go
+++ b/forge.go
@@ -708,6 +708,29 @@ func syncForgeToModuleDir(name string, m ForgeModule, moduleDir string) {
 						Fatalf(funcName + "(): Can't make " + path + " relative to " + workDir + " Error: " + err.Error())
 					}
 
+					targetInfo, err := os.Lstat(targetDir + target)
+					if err != nil && !os.IsNotExist(err) {
+						Fatalf(funcName + "(): Failed to stat target file " + path + " relative to " + workDir + " Error: " + err.Error())
+					}
+
+					if targetInfo != nil {
+						// target and source are
+						// already hardlinked,
+						// exit early
+						if os.SameFile(info, targetInfo) {
+							return nil
+						}
+
+						//.Remove file if it
+						// exists and is not
+						// already hardlinked to
+						// the target
+						if err := os.Remove(targetDir + path); err != nil {
+							Fatalf(funcName + "(): Failed to remote target file " + path + " relative to " + workDir + " Error: " + err.Error())
+							return err
+						}
+					}
+
 					if info.IsDir() {
 						//Debugf(funcName + "() Trying to mkdir " + targetDir + target)
 						err = os.Mkdir(targetDir+target, os.FileMode(0755))


### PR DESCRIPTION
We're having a few problem with failures on `os.Link` and existing hardlinks returning `os.LinkError` with `file exists`.
I don't know if this is a change with go 1.8-r1, but it doesn't always happen.

Either way, the existence of the target should be checked before attempting to hardlink it.