### PR TITLE
grabbing version from tag name

### DIFF
--- a/g10k.go
+++ b/g10k.go
@@ -175,8 +175,11 @@ func main() {
 	configFile = *configFileFlag
 	version := *versionFlag
 
+	tag_out, _ := exec.Command("git", "describe", "--tags").Output()
+	tag_version := string(tag_out[1:len(tag_out)-1])
+
 	if version {
-		fmt.Println("g10k version 0.4.3 Build time:", buildtime, "UTC")
+		fmt.Printf("g10k version %s Build time: buildtime UTC\n", tag_version)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
the change will allow to grab the version number from the tag name
it seems to be working even from the master branch, which is surprising: it take the latest tag number