### PR TITLE
Added tag and rename output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,14 @@ Usage of ./g10k:
         log verbose output, defaults to false
   -version
         show build time and version number
+  -tags
+        to also clone tags as well as branches
+  -outputname string
+        overwrite the output name if either -tag or -branch is specified
 ```
 
-Regarding anything usage/workflow you really can just use the great [puppetlabs/r10k](https://github.com/puppetlabs/r10k/blob/master/doc/dynamic-environments.mkd) docs as the [Puppetfile](https://github.com/puppetlabs/r10k/blob/master/doc/puppetfile.mkd) etc. are all intentionally kept unchanged. 
-  
+Regarding anything usage/workflow you really can just use the great [puppetlabs/r10k](https://github.com/puppetlabs/r10k/blob/master/doc/dynamic-environments.mkd) docs as the [Puppetfile](https://github.com/puppetlabs/r10k/blob/master/doc/puppetfile.mkd) etc. are all intentionally kept unchanged.
+
 
 # additional Puppetfile features
 
@@ -268,7 +272,7 @@ sources:
     basedir: '/tmp/failing/'
 ```
 
-If you then call g10k with this config file and at least the `info` verbosity level, you should get: 
+If you then call g10k with this config file and at least the `info` verbosity level, you should get:
 
 ```
 Failed to populate module /tmp/failing/master/modules//sensu/ but ignore-unreachable is set. Continuing...

--- a/g10k.go
+++ b/g10k.go
@@ -27,6 +27,8 @@ var (
 	moduleDirParam         string
 	cacheDirParam          string
 	branchParam            string
+	tags                   bool
+	outputNameParam        string
 	moduleParam            string
 	configFile             string
 	config                 ConfigSettings
@@ -152,6 +154,8 @@ func main() {
 		versionFlag    = flag.Bool("version", false, "show build time and version number")
 	)
 	flag.StringVar(&branchParam, "branch", "", "which git branch of the Puppet environment to update, e.g. core_foobar")
+	flag.BoolVar(&tags, "tags", false, "to pull tags as well as branches")
+	flag.StringVar(&outputNameParam, "outputname", "", "overwrite the environment name if -branch is specified")
 	flag.StringVar(&moduleParam, "module", "", "which module of the Puppet environment to update, e.g. stdlib")
 	flag.StringVar(&moduleDirParam, "moduledir", "", "allows overriding of Puppetfile specific moduledir setting, the folder in which Puppet modules will be extracted")
 	flag.StringVar(&cacheDirParam, "cachedir", "", "allows overriding of the g10k config file cachedir setting, the folder in which g10k will download git repositories and Forge modules")
@@ -198,6 +202,9 @@ func main() {
 		if pfMode {
 			Fatalf("Error: -puppetfile parameter is not allowed with -config parameter!")
 		}
+		if (len(outputNameParam) > 0) && (len(branchParam) == 0) {
+			Fatalf("Error: -outputname specified without -branch!")
+		}
 		if usecacheFallback {
 			config.UseCacheFallback = true
 		}
@@ -205,10 +212,10 @@ func main() {
 		config = readConfigfile(configFile)
 		target = configFile
 		if len(branchParam) > 0 {
-			resolvePuppetEnvironment(branchParam)
+			resolvePuppetEnvironment(branchParam, tags, outputNameParam)
 			target += " with branch " + branchParam
 		} else {
-			resolvePuppetEnvironment("")
+			resolvePuppetEnvironment("", tags, "")
 		}
 	} else {
 		if pfMode {

--- a/g10k_test.go
+++ b/g10k_test.go
@@ -93,7 +93,7 @@ func TestResolvConfigAddWarning(t *testing.T) {
 	funcName := strings.Split(funcName(), ".")[len(strings.Split(funcName(), "."))-1]
 	config = readConfigfile("tests/TestConfigAddWarning.yaml")
 	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
-		resolvePuppetEnvironment("nonExistingBranch")
+		resolvePuppetEnvironment("nonExistingBranch", false, "")
 		return
 	}
 
@@ -127,7 +127,7 @@ func TestResolvStatic(t *testing.T) {
 	config = readConfigfile("tests/TestConfigStatic.yaml")
 	// increase maxworker to finish the test quicker
 	config.Maxworker = 500
-	resolvePuppetEnvironment("static")
+	resolvePuppetEnvironment("static", false, "")
 
 	cmd := exec.Command(path, "-vvv", "-l", "-r", "./example", "-a", "-k", "tests/hashdeep_example_static.hashdeep")
 	out, err := cmd.CombinedOutput()
@@ -170,7 +170,7 @@ func TestConfigGlobalAllowFail(t *testing.T) {
 	config = readConfigfile("tests/" + funcName + ".yaml")
 
 	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
-		resolvePuppetEnvironment("")
+		resolvePuppetEnvironment("", false, "")
 		return
 	}
 
@@ -379,7 +379,7 @@ func TestResolvConfigExitIfUnreachable(t *testing.T) {
 	config = readConfigfile("tests/TestConfigExitIfUnreachable.yaml")
 	purgeDir(config.CacheDir, "TestResolvConfigExitIfUnreachable()")
 	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
-		resolvePuppetEnvironment("single")
+		resolvePuppetEnvironment("single", false, "")
 		return
 	}
 
@@ -406,7 +406,7 @@ func TestResolvConfigExitIfUnreachableFalse(t *testing.T) {
 	config = readConfigfile("tests/TestConfigExitIfUnreachableFalse.yaml")
 	purgeDir(config.CacheDir, "TestResolvConfigExitIfUnreachableFalse()")
 	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
-		resolvePuppetEnvironment("single")
+		resolvePuppetEnvironment("single", false, "")
 		return
 	}
 
@@ -432,7 +432,7 @@ func TestConfigUseCacheFallback(t *testing.T) {
 	funcName := strings.Split(funcName(), ".")[len(strings.Split(funcName(), "."))-1]
 	config = readConfigfile("tests/" + funcName + ".yaml")
 	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
-		resolvePuppetEnvironment("single_fail")
+		resolvePuppetEnvironment("single_fail", false, "")
 		return
 	} else {
 
@@ -481,7 +481,7 @@ func TestConfigUseCacheFallbackFalse(t *testing.T) {
 	funcName := strings.Split(funcName(), ".")[len(strings.Split(funcName(), "."))-1]
 	config = readConfigfile("tests/" + funcName + ".yaml")
 	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
-		resolvePuppetEnvironment("single_fail")
+		resolvePuppetEnvironment("single_fail", false, "")
 		return
 	} else {
 
@@ -530,7 +530,7 @@ func TestReadPuppetfileUseCacheFallback(t *testing.T) {
 	funcName := strings.Split(funcName(), ".")[len(strings.Split(funcName(), "."))-1]
 	config = readConfigfile("tests/TestConfigUseCacheFallback.yaml")
 	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
-		resolvePuppetEnvironment("single_fail_forge")
+		resolvePuppetEnvironment("single_fail_forge", false, "")
 		return
 	} else {
 		fm := ForgeModule{version: "1.9.0", author: "puppetlabs", name: "firewall"}
@@ -566,7 +566,7 @@ func TestReadPuppetfileUseCacheFallbackFalse(t *testing.T) {
 	purgeDir("/tmp/example", funcName)
 	purgeDir(config.ForgeCacheDir, funcName)
 	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
-		resolvePuppetEnvironment("single_fail_forge")
+		resolvePuppetEnvironment("single_fail_forge", false, "")
 		return
 	}
 
@@ -597,7 +597,7 @@ func TestResolvePuppetfileInstallPath(t *testing.T) {
 	config = readConfigfile("tests/TestConfigUseCacheFallback.yaml")
 	purgeDir("/tmp/example", funcName)
 	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
-		resolvePuppetEnvironment("install_path")
+		resolvePuppetEnvironment("install_path", false, "")
 		return
 	}
 
@@ -637,8 +637,8 @@ func TestResolvePuppetfileInstallPathTwice(t *testing.T) {
 	config = readConfigfile("tests/TestConfigUseCacheFallback.yaml")
 	purgeDir("/tmp/example", funcName)
 	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
-		resolvePuppetEnvironment("install_path")
-		resolvePuppetEnvironment("install_path")
+		resolvePuppetEnvironment("install_path", false, "")
+		resolvePuppetEnvironment("install_path", false, "")
 		return
 	}
 
@@ -681,11 +681,11 @@ func TestResolvePuppetfileSingleModuleForge(t *testing.T) {
 	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
 		moduleParam = "stdlib"
 		//debug = true
-		resolvePuppetEnvironment("single_module")
+		resolvePuppetEnvironment("single_module", false, "")
 		return
 	} else {
 		purgeDir("/tmp/example", funcName)
-		resolvePuppetEnvironment("single_module")
+		resolvePuppetEnvironment("single_module", false, "")
 		if !fileExists(metadataFile) {
 			t.Errorf("resolvePuppetEnvironment() terminated with the correct exit code, but the resolved metadata.json is missing %s", metadataFile)
 		}
@@ -734,11 +734,11 @@ func TestResolvePuppetfileSingleModuleGit(t *testing.T) {
 	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
 		moduleParam = "firewall"
 		//debug = true
-		resolvePuppetEnvironment("single_module")
+		resolvePuppetEnvironment("single_module", false, "")
 		return
 	} else {
 		purgeDir("/tmp/example", funcName)
-		resolvePuppetEnvironment("single_module")
+		resolvePuppetEnvironment("single_module", false, "")
 		if !fileExists(metadataFile) {
 			t.Errorf("resolvePuppetEnvironment() expected module metadata.json is missing %s", metadataFile)
 		}
@@ -786,11 +786,11 @@ func TestResolvePuppetfileFallback(t *testing.T) {
 	metadataFile := aptDir + "/metadata.json"
 	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
 		debug = true
-		resolvePuppetEnvironment("fallback")
+		resolvePuppetEnvironment("fallback", false, "")
 		return
 	} else {
 		purgeDir("/tmp/example", funcName)
-		resolvePuppetEnvironment("fallback")
+		resolvePuppetEnvironment("fallback", false, "")
 		if !fileExists(metadataFile) {
 			t.Errorf("resolvePuppetEnvironment() expected module metadata.json is missing %s", metadataFile)
 		}
@@ -839,11 +839,11 @@ func TestResolvePuppetfileDefaultBranch(t *testing.T) {
 	metadataFile := apacheDir + "/metadata.json"
 	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
 		debug = true
-		resolvePuppetEnvironment("default_branch")
+		resolvePuppetEnvironment("default_branch", false, "")
 		return
 	} else {
 		purgeDir("/tmp/example", funcName)
-		resolvePuppetEnvironment("default_branch")
+		resolvePuppetEnvironment("default_branch", false, "")
 		if !fileExists(metadataFile) {
 			t.Errorf("resolvePuppetEnvironment() expected module metadata.json is missing %s", metadataFile)
 		}
@@ -892,11 +892,11 @@ func TestResolvePuppetfileControlBranch(t *testing.T) {
 	metadataFile := apacheDir + "/metadata.json"
 	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
 		debug = true
-		resolvePuppetEnvironment("control_branch")
+		resolvePuppetEnvironment("control_branch", false, "")
 		return
 	} else {
 		purgeDir("/tmp/example", funcName)
-		resolvePuppetEnvironment("control_branch")
+		resolvePuppetEnvironment("control_branch", false, "")
 		if !fileExists(metadataFile) {
 			t.Errorf("resolvePuppetEnvironment() expected module metadata.json is missing %s", metadataFile)
 		}
@@ -942,7 +942,7 @@ func TestConfigRetryGitCommands(t *testing.T) {
 	funcName := strings.Split(funcName(), ".")[len(strings.Split(funcName(), "."))-1]
 	config = readConfigfile("tests/" + funcName + ".yaml")
 	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
-		resolvePuppetEnvironment("single_git")
+		resolvePuppetEnvironment("single_git", false, "")
 		return
 	} else {
 
@@ -993,7 +993,7 @@ func TestResolvePuppetfileLocalModules(t *testing.T) {
 	config = readConfigfile("tests/TestConfigPrefix.yaml")
 	if os.Getenv("TEST_FOR_CRASH_"+funcName) == "1" {
 		debug = true
-		resolvePuppetEnvironment("local_modules")
+		resolvePuppetEnvironment("local_modules", false, "")
 		return
 	}
 

--- a/puppetfile.go
+++ b/puppetfile.go
@@ -27,7 +27,7 @@ func sourceSanityCheck(source string, sa Source) {
 	}
 }
 
-func resolvePuppetEnvironment(envBranch string) {
+func resolvePuppetEnvironment(envBranch string, tags bool, outputNameTag string) {
 	wg := sizedwaitgroup.New(config.MaxExtractworker + 1)
 	allPuppetfiles := make(map[string]Puppetfile)
 	for source, sa := range config.Sources {
@@ -52,7 +52,16 @@ func resolvePuppetEnvironment(envBranch string) {
 
 				// get all branches
 				er := executeCommand("git --git-dir "+workDir+" branch", config.Timeout, false)
-				branches := strings.Split(strings.TrimSpace(er.output), "\n")
+				output_branches := er.output
+				output_tags := ""
+
+				if (tags == true) {
+					er := executeCommand("git --git-dir "+workDir+" tag", config.Timeout, false)
+					output_tags = er.output
+				}
+
+				branches := strings.Split(strings.TrimSpace(output_branches + output_tags), "\n")
+
 
 				foundBranch := false
 				for _, branch := range branches {
@@ -72,11 +81,17 @@ func resolvePuppetEnvironment(envBranch string) {
 						if len(branch) != 0 {
 							Debugf("Resolving branch: " + branch)
 
-							targetDir := sa.Basedir + sa.Prefix + "_" + strings.Replace(branch, "/", "_", -1)
+							renamed_branch := branch
+							if (len(outputNameTag) > 0) && (len(envBranch) > 0) {
+								renamed_branch = outputNameTag
+								Debugf("Renaming branch " + branch + " to " + renamed_branch)
+							}
+
+							targetDir := sa.Basedir + sa.Prefix + "_" + strings.Replace(renamed_branch, "/", "_", -1)
 							if sa.Prefix == "false" || sa.Prefix == "" {
-								targetDir = sa.Basedir + strings.Replace(branch, "/", "_", -1)
+								targetDir = sa.Basedir + strings.Replace(renamed_branch, "/", "_", -1)
 							} else if sa.Prefix == "true" {
-								targetDir = sa.Basedir + source + "_" + strings.Replace(branch, "/", "_", -1)
+								targetDir = sa.Basedir + source + "_" + strings.Replace(renamed_branch, "/", "_", -1)
 							}
 							targetDir = normalizeDir(targetDir)
 

--- a/puppetfile.go
+++ b/puppetfile.go
@@ -62,7 +62,6 @@ func resolvePuppetEnvironment(envBranch string, tags bool, outputNameTag string)
 
 				branches := strings.Split(strings.TrimSpace(output_branches + output_tags), "\n")
 
-
 				foundBranch := false
 				for _, branch := range branches {
 					branch = strings.TrimLeft(branch, "* ")
@@ -81,17 +80,17 @@ func resolvePuppetEnvironment(envBranch string, tags bool, outputNameTag string)
 						if len(branch) != 0 {
 							Debugf("Resolving branch: " + branch)
 
-							renamed_branch := branch
+							renamedBranch := branch
 							if (len(outputNameTag) > 0) && (len(envBranch) > 0) {
-								renamed_branch = outputNameTag
-								Debugf("Renaming branch " + branch + " to " + renamed_branch)
+								renamedBranch = outputNameTag
+								Debugf("Renaming branch " + branch + " to " + renamedBranch)
 							}
 
-							targetDir := sa.Basedir + sa.Prefix + "_" + strings.Replace(renamed_branch, "/", "_", -1)
+							targetDir := sa.Basedir + sa.Prefix + "_" + strings.Replace(renamedBranch, "/", "_", -1)
 							if sa.Prefix == "false" || sa.Prefix == "" {
-								targetDir = sa.Basedir + strings.Replace(renamed_branch, "/", "_", -1)
+								targetDir = sa.Basedir + strings.Replace(renamedBranch, "/", "_", -1)
 							} else if sa.Prefix == "true" {
-								targetDir = sa.Basedir + source + "_" + strings.Replace(renamed_branch, "/", "_", -1)
+								targetDir = sa.Basedir + source + "_" + strings.Replace(renamedBranch, "/", "_", -1)
 							}
 							targetDir = normalizeDir(targetDir)
 


### PR DESCRIPTION
I have a project where I want to deploy tagged builds puppet resources without ending up loads of environments. So I've added the ability include tags as well as branches.

I've also added the ability to rename the output folder. My intention is to get a specific tag using the -branch option and then renaming it to a name. E.g. tag 1.0.0 renamed to production.