### PR TITLE
Print fatal errors to stderr instead of stdout

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -52,7 +52,7 @@ func Warnf(s string) {
 
 // Fatalf is a helper function for fatal logging
 func Fatalf(s string) {
-	color.Red(s)
+	color.New(color.FgRed).Fprintln(os.Stderr, s)
 	os.Exit(1)
 }
 


### PR DESCRIPTION
This helps grabbing error messages when calling g10k from a script or wrapper tool.