### PR TITLE
Puppetfile validation

### DIFF
--- a/config.go
+++ b/config.go
@@ -99,6 +99,10 @@ func readConfigfile(configFile string) ConfigSettings {
 		config.MaxExtractworker = 20
 	}
 
+	if validate {
+		Validatef()
+	}
+
 	return config
 }
 
@@ -372,6 +376,10 @@ func readPuppetfile(pf string, sshKey string, source string, forceForgeVersions 
 	if len(moduleDirs) < 1 {
 		// adding at least the default module directory
 		moduleDirs = append(moduleDirs, moduleDir)
+	}
+
+	if validate {
+		Validatef()
 	}
 
 	puppetFile.moduleDirs = moduleDirs

--- a/config.go
+++ b/config.go
@@ -110,6 +110,7 @@ func preparePuppetfile(pf string) string {
 	}
 	defer file.Close()
 
+	reComma := regexp.MustCompile(",\\s*$")
 	reComment := regexp.MustCompile("^\\s*#")
 	reEmpty := regexp.MustCompile("^$")
 
@@ -122,7 +123,7 @@ func preparePuppetfile(pf string) string {
 				Debugf("found inline comment in " + pf + "line: " + line)
 				line = strings.Split(line, "#")[0]
 			}
-			if regexp.MustCompile(",\\s*$").MatchString(line) {
+			if reComma.MatchString(line) {
 				pfString += line
 				Debugf("adding line:" + line)
 			} else {

--- a/g10k.go
+++ b/g10k.go
@@ -23,6 +23,7 @@ var (
 	pfMode                       bool
 	pfLocation                   string
 	dryRun                       bool
+	validate                     bool
 	check4update                 bool
 	checkSum                     bool
 	gitObjectSyntaxNotSupported  bool
@@ -187,6 +188,7 @@ func main() {
 	flag.StringVar(&pfLocation, "puppetfilelocation", "./Puppetfile", "which Puppetfile to use in -puppetfile mode")
 	flag.BoolVar(&force, "force", false, "purge the Puppet environment directory and do a full sync")
 	flag.BoolVar(&dryRun, "dryrun", false, "do not modify anything, just print what would be changed")
+	flag.BoolVar(&validate, "validate", false, "only validate given configuration and exit")
 	flag.BoolVar(&usemove, "usemove", false, "do not use hardlinks to populate your Puppet environments with Puppetlabs Forge modules. Instead uses simple move commands and purges the Forge cache directory after each run! (Useful for g10k runs inside a Docker container)")
 	flag.BoolVar(&check4update, "check4update", false, "only check if the is newer version of the Puppet module avaialable. Does implicitly set dryrun to true")
 	flag.BoolVar(&checkSum, "checksum", false, "get the md5 check sum for each Puppetlabs Forge module and verify the integrity of the downloaded archive. Increases g10k run time!")

--- a/helper.go
+++ b/helper.go
@@ -17,6 +17,8 @@ import (
 	"github.com/kballard/go-shellquote"
 )
 
+var validationMessages []string
+
 // Debugf is a helper function for debug logging if global variable debug is set to true
 func Debugf(s string) {
 	if debug != false {
@@ -45,6 +47,19 @@ func Infof(s string) {
 	}
 }
 
+// Validatef is a helper function for validation logging if global variable validate is set to true
+func Validatef() {
+	if len(validationMessages) > 0 {
+		for _, message := range validationMessages {
+			color.New(color.FgRed).Fprintln(os.Stdout, message)
+		}
+		os.Exit(1)
+	} else {
+		color.New(color.FgGreen).Fprintln(os.Stdout, "Configuration successfully parsed.")
+		os.Exit(0)
+	}
+}
+
 // Warnf is a helper function for warning logging
 func Warnf(s string) {
 	color.Set(color.FgYellow)
@@ -54,8 +69,12 @@ func Warnf(s string) {
 
 // Fatalf is a helper function for fatal logging
 func Fatalf(s string) {
-	color.New(color.FgRed).Fprintln(os.Stderr, s)
-	os.Exit(1)
+	if validate {
+		validationMessages = append(validationMessages, s)
+	} else {
+		color.New(color.FgRed).Fprintln(os.Stderr, s)
+		os.Exit(1)
+	}
 }
 
 // fileExists checks if the given file exists and returns a bool


### PR DESCRIPTION
Hi,

we are currently investigating a method to validate a given Puppetfile even before a sync is actually triggered and I wondered if you could incorporate such a functionality in g10k.
I build a example implementation of this feature, so it's clearer what I want to achieve. The added '-validate' flag forces the program to exit right after it parsed a given config or Puppetfile and prints all errors that it collected during the process. The exit code is 1 in case something went wrong, and 0 if the file was parsed without a problem.

greetings
Phillip