### PR TITLE
Add check in puppetfile if brach is set to :control_branch

### DIFF
--- a/config.go
+++ b/config.go
@@ -322,8 +322,13 @@ func readPuppetfile(pf string, sshKey string, source string, forceForgeVersions 
 						if a[2] == ":control_branch" || a[2] == "control_branch" {
 							if strings.HasPrefix(a[2], ":") {
 								a[2] = strings.TrimLeft(a[2], ":")
+								gm.control_branch = true
+							} else {
+								gm.control_branch = false
 							}
 							gm.link = true
+						} else {
+							gm.control_branch = false
 						}
 						gm.branch = a[2]
 					} else if gitModuleAttribute == "tag" {

--- a/g10k.go
+++ b/g10k.go
@@ -148,6 +148,7 @@ type GitModule struct {
 	installPath       string
 	local             bool
 	moduleDir         string
+	control_branch    bool
 }
 
 // ForgeResult is returned by queryForgeAPI and contains if and which version of the Puppetlabs Forge module needs to be downloaded

--- a/puppetfile.go
+++ b/puppetfile.go
@@ -276,7 +276,7 @@ func resolvePuppetfile(allPuppetfiles map[string]Puppetfile) {
 				targetDir := normalizeDir(moduleDir + gitName)
 				//fmt.Println("targetDir: " + targetDir)
 				tree := "master"
-                if gitModule.control_branch {
+				if gitModule.control_branch {
 					tree = branchParam
 				} else if len(gitModule.branch) > 0 {
 					tree = gitModule.branch

--- a/puppetfile.go
+++ b/puppetfile.go
@@ -276,7 +276,9 @@ func resolvePuppetfile(allPuppetfiles map[string]Puppetfile) {
 				targetDir := normalizeDir(moduleDir + gitName)
 				//fmt.Println("targetDir: " + targetDir)
 				tree := "master"
-				if len(gitModule.branch) > 0 {
+                if gitModule.control_branch {
+					tree = branchParam
+				} else if len(gitModule.branch) > 0 {
 					tree = gitModule.branch
 				} else if len(gitModule.commit) > 0 {
 					tree = gitModule.commit


### PR DESCRIPTION
Hey,

We are used r10k deploying an environment with a use of control_branch. When you set the a specific  environment it uses the environment brach if it exists else it fetches the default specified in `Puppetfile`. 

When I use g10k with a `config` parameter it set the branch name with `:control_branch` filled in and it has more priority then `tree` attribute, when it clones the git repo it uses the branch `control_branch` instead of set environment branch.

To solve this I have added a extra parameter to the `GitModule` struct for a `control_branch`.

Greetz,
Egbert