### PR TITLE
Clean up output, implement timeout, do not update the whole index when deploying a branch

### DIFF
--- a/g10k.go
+++ b/g10k.go
@@ -158,10 +158,11 @@ type ForgeResult struct {
 	fileSize      int64
 }
 
-// ExecResult contains the exit code and output of an external command (e.g. git)
+// ExecResult contains the exit code, output of an external command (e.g. git), and the error (if any)
 type ExecResult struct {
 	returnCode int
 	output     string
+	err        error
 }
 
 func init() {

--- a/helper.go
+++ b/helper.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -165,7 +166,6 @@ func purgeDir(dir string, callingFunction string) {
 }
 
 func executeCommand(command string, timeout int, allowFail bool) ExecResult {
-	Debugf("Executing " + command)
 	parts := strings.SplitN(command, " ", 2)
 	cmd := parts[0]
 	cmdArgs := []string{}
@@ -178,9 +178,21 @@ func executeCommand(command string, timeout int, allowFail bool) ExecResult {
 		}
 	}
 
+	var ctx context.Context
+	var cancel context.CancelFunc
+	if timeout > 0 {
+		ctx, cancel = context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+		defer cancel()
+	} else {
+		ctx = context.Background()
+	}
+
 	before := time.Now()
-	out, err := exec.Command(cmd, cmdArgs...).CombinedOutput()
+	out, err := exec.CommandContext(ctx, cmd, cmdArgs...).CombinedOutput()
 	duration := time.Since(before).Seconds()
+
+	Debugf("Executing " + command + " gave output: " + string(out) + ", and error: " + err.Error())
+
 	er := ExecResult{0, string(out), err}
 	if msg, ok := err.(*exec.ExitError); ok { // there is error code
 		er.returnCode = msg.Sys().(syscall.WaitStatus).ExitStatus()

--- a/helper.go
+++ b/helper.go
@@ -181,7 +181,7 @@ func executeCommand(command string, timeout int, allowFail bool) ExecResult {
 	before := time.Now()
 	out, err := exec.Command(cmd, cmdArgs...).CombinedOutput()
 	duration := time.Since(before).Seconds()
-	er := ExecResult{0, string(out)}
+	er := ExecResult{0, string(out), err}
 	if msg, ok := err.(*exec.ExitError); ok { // there is error code
 		er.returnCode = msg.Sys().(syscall.WaitStatus).ExitStatus()
 	}
@@ -200,7 +200,6 @@ func executeCommand(command string, timeout int, allowFail bool) ExecResult {
 			}
 		} else {
 			er.returnCode = 1
-			er.output = fmt.Sprint(err)
 		}
 	}
 	return er

--- a/puppetfile.go
+++ b/puppetfile.go
@@ -52,7 +52,7 @@ func resolvePuppetEnvironment(envBranch string, tags bool, outputNameTag string)
 			// check if sa.Basedir exists
 			checkDirAndCreate(sa.Basedir, "basedir")
 
-			if success := doMirrorOrUpdate(sa.Remote, workDir, sa.PrivateKey, true, 1); success {
+			if success := doMirrorOrUpdate(sa.Remote, workDir, sa.PrivateKey, envBranch, true, 1); success {
 
 				// get all branches
 				er := executeCommand("git --git-dir "+workDir+" branch", config.Timeout, false)


### PR DESCRIPTION
Some set of fixes that I've done to make g10k usable on a large deployment:

* Do not lock the whole index when deploying a specified branch (main use-case). Achieve this by using `git fetch ...` instead of doing `git remote update --prune` each time if we are interested only in one branch. git isn't too happy with >1 concurrent writers
* Implement the timeout functionality. Make proper contexts and pass them to `CommandContext()`
* Add a proper debug output with the command name + output + the error 