### PR TITLE
Check writability of configured CacheDir.

### DIFF
--- a/g10k.go
+++ b/g10k.go
@@ -235,6 +235,7 @@ func main() {
 		}
 		Debugf("Using as config file: " + configFile)
 		config = readConfigfile(configFile)
+		checkDirAndCreate(config.CacheDir, "cachedir configured value")
 		target = configFile
 		if len(branchParam) > 0 {
 			resolvePuppetEnvironment(branchParam, tags, outputNameParam)

--- a/helper.go
+++ b/helper.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/kballard/go-shellquote"
+	"golang.org/x/sys/unix"
 )
 
 var validationMessages []string
@@ -122,6 +123,10 @@ func checkDirAndCreate(dir string, name string) string {
 			} else {
 				if !isDir(dir) {
 					Fatalf("checkDirAndCreate(): Error: " + dir + " exists, but is not a directory! Exiting!")
+				} else {
+					if unix.Access(dir, unix.W_OK) != nil {
+						Fatalf("checkDirAndCreate(): Error: " + dir + " exists, but is not writable! Exiting!")
+					}
 				}
 			}
 		} else {


### PR DESCRIPTION
Fixes: #136 

I was getting some confusing segfaults when the ownership of the g10k CacheDir was wrong.

The program should print an error instead of segfaulting.  I'm hoping this change does the trick, but I've never written in Golang before.