### PR TITLE
Really respect `maxworker` parameter during git clone/remote update, close #140

### DIFF
--- a/git.go
+++ b/git.go
@@ -84,8 +84,8 @@ func resolveGitRepositories(uniqueGitModules map[string]GitModule) {
 				Fatalf("Fatal: Could not reach git repository " + url)
 			}
 			//	doCloneOrPull(source, workDir, targetDir, sa.Remote, branch, sa.PrivateKey)
+            done <- true
 		}(url, privateKey, gm, bar)
-		done <- true
 	}
 
 	// Wait for all jobs to finish


### PR DESCRIPTION
It seems that since it has been implemented, maxworker does not work correctly.
The main reason is that the  `done` channel is filled outside of the go loop which spawn the func : https://github.com/xorpaul/g10k/blob/master/git.go#L88 

Moving it to the end of the goroutine makes maxworker work correctly.