### PR TITLE
add branch filtering

### DIFF
--- a/g10k.go
+++ b/g10k.go
@@ -131,6 +131,8 @@ type Source struct {
 	WarnMissingBranch           bool   `yaml:"warn_if_branch_is_missing"`
 	ExitIfUnreachable           bool   `yaml:"exit_if_unreachable"`
 	AutoCorrectEnvironmentNames string `yaml:"invalid_branches"`
+	FilterCommand               string `yaml:"filter_command"`
+	FilterRegex                 string `yaml:"filter_regex"`
 }
 
 // Puppetfile contains the key value pairs from the Puppetfile

--- a/tests/TestConfigFullworkingBranchFilter.yaml
+++ b/tests/TestConfigFullworkingBranchFilter.yaml
@@ -1,0 +1,13 @@
+---
+:cachedir: '/tmp/g10k'
+
+sources:
+  full:
+    remote: 'https://github.com/xorpaul/g10k-fullworking-env.git'
+    basedir: '/tmp/branchfilter'
+    exit_if_unreachable: true
+    warn_if_branch_is_missing: true
+    prefix: true
+    filter_command: 'tests/branch_filter_command.sh $R10K_BRANCH ^(single|master)$'
+    ignore_branch_prefixes:
+      - 'qa'

--- a/tests/TestConfigFullworkingBranchFilterRegex.yaml
+++ b/tests/TestConfigFullworkingBranchFilterRegex.yaml
@@ -1,0 +1,13 @@
+---
+:cachedir: '/tmp/g10k'
+
+sources:
+  full:
+    remote: 'https://github.com/xorpaul/g10k-fullworking-env.git'
+    basedir: '/tmp/branchfilter'
+    exit_if_unreachable: true
+    warn_if_branch_is_missing: true
+    prefix: true
+    filter_regex: '^(single|master)$'
+    ignore_branch_prefixes:
+      - 'qa'

--- a/tests/branch_filter_command.sh
+++ b/tests/branch_filter_command.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+if [ ${#} -lt 2 ]; then
+  echo "${0} expects at least the current branch name and the regex as parameters"
+  echo "example: ${0} master ^(single|master)$"
+  exit 1
+fi
+
+if [[ ${1} =~ ${2} ]]; then
+  exit 0
+else
+  exit 1
+fi


### PR DESCRIPTION
added source settings in the g10k config yaml to filter out Puppet environments / control repository branches based on generic commands via `filter_command` or simply via Golang compatible regex `filter_regex`

Examples:

```
==> tests/TestConfigFullworkingBranchFilter.yaml <==
---
:cachedir: '/tmp/g10k'

sources:
  full:
    remote: 'https://github.com/xorpaul/g10k-fullworking-env.git'
    basedir: '/tmp/branchfilter'
    filter_command: 'tests/branch_filter_command.sh $R10K_BRANCH ^(single|master)$'
```
```
==> tests/TestConfigFullworkingBranchFilterRegex.yaml <==
---
:cachedir: '/tmp/g10k'

sources:
  full:
    remote: 'https://github.com/xorpaul/g10k-fullworking-env.git'
    basedir: '/tmp/branchfilter'
    filter_regex: '^(single|master)$'
```
