### PR TITLE
Export git_dir in .g10k-deploy.json

### DIFF
--- a/g10k.go
+++ b/g10k.go
@@ -145,6 +145,7 @@ type Puppetfile struct {
 	source            string
 	sourceBranch      string
 	workDir           string
+	gitDir            string
 	moduleDirs        []string
 	controlRepoBranch string
 }
@@ -202,6 +203,7 @@ type DeployResult struct {
 	FinishedAt         time.Time `json:"finished_at"`
 	DeploySuccess      bool      `json:"deploy_success"`
 	PuppetfileChecksum string    `json:"puppetfile_checksum"`
+	GitDir             string    `json:"git_dir"`
 }
 
 func init() {

--- a/puppetfile.go
+++ b/puppetfile.go
@@ -158,6 +158,7 @@ func resolvePuppetEnvironment(tags bool, outputNameTag string) {
 								puppetfile := readPuppetfile(pf, sa.PrivateKey, source, branch, sa.ForceForgeVersions, false)
 								puppetfile.workDir = normalizeDir(targetDir)
 								puppetfile.controlRepoBranch = branch
+								puppetfile.gitDir = workDir
 								mutex.Lock()
 								for _, moduleDir := range puppetfile.moduleDirs {
 									desiredContent = append(desiredContent, filepath.Join(puppetfile.workDir, moduleDir))
@@ -448,6 +449,7 @@ func resolvePuppetfile(allPuppetfiles map[string]Puppetfile) {
 			dr.DeploySuccess = true
 			dr.FinishedAt = time.Now()
 			dr.PuppetfileChecksum = getSha256sumFile(filepath.Join(pf.workDir, "Puppetfile"))
+			dr.GitDir = pf.gitDir
 			writeStructJSONFile(deployFile, dr)
 			mutex.Lock()
 			desiredContent = append(desiredContent, deployFile)


### PR DESCRIPTION
When executing Git commands in the context of Puppet (for example to retrieve the commit message in `config_version` or to generate a serial based on the last commit reference of a file in the repo), it's useful to know where the Git dir is located so you don't need to hardcode it.

This PR stores the location of the Git dir in the `.g10k-deploy.json` file so it can be retrieved easily.

E.g. `config_version` script, before:

```ruby
require 'json'
deploy_info = JSON.parse(File.read("#{__dir__}/.g10k-deploy.json"))
sha = deploy_info['signature']
git_dir = '/etc/puppetlabs/code/cache/environments/main.git'  # 😱
message = `git --git-dir #{git_dir} log -1 --pretty='%s' "#{sha}"`.chomp
```

after:

```ruby
require 'json'
deploy_info = JSON.parse(File.read("#{__dir__}/.g10k-deploy.json"))
sha = deploy_info['signature']
git_dir = deploy_info['git_dir']    # 😁
message = `git --git-dir #{git_dir} log -1 --pretty='%s' "#{sha}"`.chomp
```

