### PR TITLE
Use ssh-add -K (Keychain) for Mac OS X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tmp/
 external_modules/
 .scannerwork/
 tests/github-test-private/
+coverage.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 language: go
 
 go:
@@ -5,3 +6,10 @@ go:
   - tip
 
 dist: bionic
+
+os:
+  - linux
+  - osx
+
+env:
+  - GO111MODULE=on

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,23 @@
-FROM golang:1.13 as builder
-WORKDIR /go/src/github.com/xorpaul/g10k
-COPY . .
-RUN make g10k
+FROM golang:1.15-alpine as builder
+WORKDIR /usr/src/g10k
+COPY . /usr/src/g10k
+RUN apk add --no-cache gcc make musl-dev git openssh bash && \
+    make g10k
 
-FROM puppet/r10k:3.1.0
-COPY --from=builder /go/src/github.com/xorpaul/g10k/g10k /usr/local/bin/
-ENTRYPOINT ["/usr/local/bin/g10k"]
-RUN apt-get update && apt-get install -y git && apt-get clean
-CMD [""]
+FROM puppet/r10k:3.7.0
+COPY --from=builder /usr/src/g10k/g10k /usr/bin/
+COPY Dockerfile /Dockerfile
+LABEL org.label-schema.maintainer="Benjamin Kübler <g10k-docker@kuebler.email>" \
+      org.label-schema.vendor="Andreas Paul" \
+      org.label-schema.url="https://github.com/xorpaul/g10k" \
+      org.label-schema.name="g10k" \
+      org.label-schema.license="Apache-2.0" \
+      org.label-schema.vcs-url="https://github.com/xorpaul/g10k" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.dockerfile="/Dockerfile"
+WORKDIR /code
+USER root
+RUN apk add --no-cache git openssh bash
+USER puppet
+ENTRYPOINT [ "/usr/bin/g10k" ]
+CMD ["-help"]

--- a/Makefile
+++ b/Makefile
@@ -36,4 +36,7 @@ test: lint vet imports
 clean:
 	rm -f g10k coverage.txt
 
+build-image:
+	docker build -t g10k:${BUILDVERSION} .
+
 .PHONY: all lint vet imports test clean

--- a/Makefile
+++ b/Makefile
@@ -1,43 +1,39 @@
 DEPS = $(wildcard */*.go)
-VERSION = $(shell git describe --always)
+BUILDVERSION = $(shell git describe --tags)
+BUILDTIME = $(shell date -u '+%Y-%m-%d_%H:%M:%S')
+UNAME := $(shell uname)
 
 all: test g10k
 
 g10k: g10k.go $(DEPS)
+ifeq ($(UNAME), Darwin)
+	GO111MODULE=on CGO_ENABLED=1 GOOS=darwin go build \
+		-race -ldflags "-s -w -X main.buildversion=${BUILDVERSION} -X main.buildtime=${BUILDTIME}" \
+	-o $@
+	strip -X $@
+endif
+ifeq ($(UNAME), Linux)
 	GO111MODULE=on CGO_ENABLED=1 GOOS=linux go build \
-	  -ldflags "-linkmode external -extldflags -static -X main.version=$(VERSION)" \
+		-race -ldflags "-s -w -X main.buildversion=${BUILDVERSION} -X main.buildtime=${BUILDTIME}" \
 	-o $@
 	strip $@
+endif
 
 lint:
-	@ go get -v golang.org/x/lint/golint
-	@for file in $$(git ls-files '*.go' | grep -v '_workspace/'); do \
-		export output="$$(golint $${file} | grep -v 'type name will be used as docker.DockerInfo')"; \
-		[ -n "$${output}" ] && echo "$${output}" && export status=1; \
-	done; \
-	exit $${status:-0}
+	GO111MODULE=on go get golang.org/x/lint/golint && \
+	golint *.go
 
-vet: main.go
-	go vet $<
+vet: g10k.go
+	GO111MODULE=on go vet
 
-imports: main.go
-	go get golang.org/x/tools/cmd/goimports && goimports -d $<
+imports: g10k.go
+	GO111MODULE=on go get golang.org/x/tools/cmd/goimports && \
+	goimports -d .
 
 test: lint vet imports
-	GO111MODULE=on go test -v ./...
-
-vendor:
-	GO111MODULE=on go mod vendor
-
-coverage:
-	rm -rf *.out
-	go test -coverprofile=coverage.out
-	for i in config util s3 db api compare auth; do \
-	 	go test -coverprofile=$$i.coverage.out github.com/xorpaul/g10k/$$i; \
-		tail -n +2 $$i.coverage.out >> coverage.out; \
-		done
+	GO111MODULE=on go test -race -coverprofile=coverage.txt -covermode=atomic -v
 
 clean:
-	rm -f g10k
+	rm -f g10k coverage.txt
 
-.PHONY: all lint vet imports test coverage clean
+.PHONY: all lint vet imports test clean

--- a/build_release.sh
+++ b/build_release.sh
@@ -19,9 +19,9 @@ fi
 # try to get the project name from the current working directory
 projectname=${PWD##*/}
 
-sed -i "s/${projectname} version [^ ]*/${projectname} version ${1}/" ${projectname}.go
-git add ${projectname}.go
-git commit -m "bump version to v${1}"
+#sed -i "s/${projectname} version [^ ]*/${projectname} version ${1}/" ${projectname}.go
+#git add ${projectname}.go
+#git commit -m "bump version to v${1}"
 
 echo "creating git tag v${1}"
 git tag v${1}
@@ -36,13 +36,13 @@ upx=`which upx`
 
 if [ ${#upx} -gt 0 ]; then
   echo "building and uploading ${projectname}-darwin-amd64-debug"
-  BUILDTIME=$(date -u '+%Y-%m-%d_%H:%M:%S') && env GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.buildtime=$BUILDTIME_v${1}" && date
+  BUILDTIME=$(date -u '+%Y-%m-%d_%H:%M:%S') BUILDVERSION=$(git describe --tags) && env GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.buildtime=$BUILDTIME_v${1} -X main.buildversion=${BUILDVERSION}" && date
   zip ${projectname}-darwin-amd64-debug.zip ${projectname}
   github-release upload     --user xorpaul     --repo ${projectname}     --tag v${1}     --name "${projectname}-darwin-amd64-debug.zip" --file ${projectname}-darwin-amd64-debug.zip
 fi
 
 echo "building and uploading ${projectname}-darwin-amd64"
-BUILDTIME=$(date -u '+%Y-%m-%d_%H:%M:%S') && env GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w -X main.buildtime=$BUILDTIME_v${1}" && date
+BUILDTIME=$(date -u '+%Y-%m-%d_%H:%M:%S') BUILDVERSION=$(git describe --tags) && env GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w -X main.buildtime=$BUILDTIME_v${1} -X main.buildversion=${BUILDVERSION}" && date
 if [ ${#upx} -gt 0 ]; then
   $upx --brute ${projectname}
 fi
@@ -55,13 +55,13 @@ github-release upload     --user xorpaul     --repo ${projectname}     --tag v${
 
 if [ ${#upx} -gt 0 ]; then
   echo "building and uploading ${projectname}-linux-amd64-debug"
-  BUILDTIME=$(date -u '+%Y-%m-%d_%H:%M:%S') && go build -race -ldflags "-X main.buildtime=$BUILDTIME_v${1}" && date && env ${projectname}_cachedir=/tmp/${projectname} ./${projectname} -config test.yaml -branch benchmark 2>&1
+  BUILDTIME=$(date -u '+%Y-%m-%d_%H:%M:%S') BUILDVERSION=$(git describe --tags) && go build -race -ldflags "-X main.buildtime=$BUILDTIME_v${1} -X main.buildversion=${BUILDVERSION}" && date && env ${projectname}_cachedir=/tmp/${projectname} ./${projectname} -config test.yaml -branch benchmark 2>&1
   zip ${projectname}-linux-amd64-debug.zip ${projectname}
   github-release upload     --user xorpaul     --repo ${projectname}     --tag v${1}     --name "${projectname}-linux-amd64-debug.zip" --file ${projectname}-linux-amd64-debug.zip
 fi
 
 echo "building and uploading ${projectname}-linux-amd64"
-BUILDTIME=$(date -u '+%Y-%m-%d_%H:%M:%S') && go build -race -ldflags "-s -w -X main.buildtime=$BUILDTIME_v${1}" && date && env ${projectname}_cachedir=/tmp/${projectname} ./${projectname} -config test.yaml -branch benchmark 2>&1
+BUILDTIME=$(date -u '+%Y-%m-%d_%H:%M:%S') BUILDVERSION=$(git describe --tags) && go build -race -ldflags "-s -w -X main.buildtime=$BUILDTIME_v${1} -X main.buildversion=${BUILDVERSION}" && date && env ${projectname}_cachedir=/tmp/${projectname} ./${projectname} -config test.yaml -branch benchmark 2>&1
 if [ ${#upx} -gt 0 ]; then
   $upx --brute ${projectname}
 fi

--- a/g10k.go
+++ b/g10k.go
@@ -52,6 +52,7 @@ var (
 	metadataJSONParseTime        float64
 	gmetadataJSONParseTime       float64
 	buildtime                    string
+	buildversion                 string
 	uniqueForgeModules           map[string]ForgeModule
 	latestForgeModules           LatestForgeModules
 	maxworker                    int
@@ -251,7 +252,7 @@ func main() {
 	version := *versionFlag
 
 	if version {
-		fmt.Println("g10k version 0.8.12 Build time:", buildtime, "UTC")
+		fmt.Println("g10k ", buildversion, " Build time:", buildtime, "UTC")
 		os.Exit(0)
 	}
 

--- a/g10k_test.go
+++ b/g10k_test.go
@@ -278,7 +278,7 @@ func TestResolveStatic(t *testing.T) {
 	// remove timestamps from .g10k-deploy.json otherwise hash sum would always differ
 	removeTimestampsFromDeployfile("example/example_static/.g10k-deploy.json")
 
-	cmd := exec.Command(path, "-vv", "-l", "-r", "./example", "-a", "-k", "tests/hashdeep_example_static.hashdeep")
+	cmd := exec.Command(path, "-vv", "-l", "-r", "-a", "-k", "tests/hashdeep_example_static.hashdeep", "./example")
 	out, err := cmd.CombinedOutput()
 	exitCode := 0
 	if msg, ok := err.(*exec.ExitError); ok { // there is error code
@@ -294,7 +294,7 @@ func TestResolveStatic(t *testing.T) {
 
 	purgeDir("example/example_static/external_modules/stdlib/spec/unit/facter/util", "TestResolveStatic()")
 
-	cmd = exec.Command("hashdeep", "-l", "-r", "./example", "-a", "-k", "tests/hashdeep_example_static.hashdeep")
+	cmd = exec.Command("hashdeep", "-l", "-r", "-a", "-k", "tests/hashdeep_example_static.hashdeep", "./example")
 	out, err = cmd.CombinedOutput()
 	exitCode = 0
 	if msg, ok := err.(*exec.ExitError); ok { // there is error code
@@ -330,7 +330,7 @@ func TestResolveStaticBlacklist(t *testing.T) {
 	// remove timestamps from .g10k-deploy.json otherwise hash sum would always differ
 	removeTimestampsFromDeployfile("example/example_blacklist/.g10k-deploy.json")
 
-	cmd := exec.Command(path, "-vv", "-l", "-r", "./example", "-a", "-k", "tests/hashdeep_example_static_blacklist.hashdeep")
+	cmd := exec.Command(path, "-vv", "-l", "-r", "-a", "-k", "tests/hashdeep_example_static_blacklist.hashdeep", "./example")
 	out, err := cmd.CombinedOutput()
 	exitCode := 0
 	if msg, ok := err.(*exec.ExitError); ok { // there is error code
@@ -357,7 +357,7 @@ func TestResolveStaticBlacklist(t *testing.T) {
 
 	purgeDir("example/example_blacklist/Puppetfile", "TestResolveStaticBlacklist()")
 
-	cmd = exec.Command(path, "-l", "-r", "./example", "-a", "-k", "tests/hashdeep_example_static_blacklist.hashdeep")
+	cmd = exec.Command(path, "-l", "-r", "-a", "-k", "tests/hashdeep_example_static_blacklist.hashdeep", "./example")
 	out, err = cmd.CombinedOutput()
 	exitCode = 0
 	if msg, ok := err.(*exec.ExitError); ok { // there is error code
@@ -2746,7 +2746,7 @@ func TestSkipPurgingWithMultipleSources(t *testing.T) {
 	removeTimestampsFromDeployfile("/tmp/out/full_single/.g10k-deploy.json")
 	removeTimestampsFromDeployfile("/tmp/out/example_single_git/.g10k-deploy.json")
 
-	cmd = exec.Command(path, "-vv", "-l", "-r", "/tmp/out", "-a", "-k", "tests/hashdeep_both_multiple.hashdeep")
+	cmd = exec.Command(path, "-vv", "-l", "-r", "-a", "-k", "tests/hashdeep_both_multiple.hashdeep", "/tmp/out")
 	out, err = cmd.CombinedOutput()
 	exitCode = 0
 	if msg, ok := err.(*exec.ExitError); ok { // there is error code
@@ -2781,7 +2781,7 @@ func TestSymlink(t *testing.T) {
 		// remove timestamps from .g10k-deploy.json otherwise hash sum would always differ
 		removeTimestampsFromDeployfile("/tmp/out/full_symlinks/.g10k-deploy.json")
 
-		cmd := exec.Command(path, "-vv", "-l", "-r", "/tmp/out", "-a", "-k", "tests/hashdeep_both_symlinks.hashdeep")
+		cmd := exec.Command(path, "-vv", "-l", "-r", "-a", "-k", "tests/hashdeep_both_symlinks.hashdeep", "/tmp/out")
 		out, err := cmd.CombinedOutput()
 		exitCode := 0
 		if msg, ok := err.(*exec.ExitError); ok { // there is error code
@@ -2810,7 +2810,7 @@ func TestSymlink(t *testing.T) {
 
 		purgeDir("/tmp/out/full_symlinks/modules/testmodule/files/docs/another_dir/file", "TestResolveStatic()")
 
-		cmd = exec.Command("hashdeep", "-l", "-r", "/tmp/out", "-a", "-k", "tests/hashdeep_both_symlinks.hashdeep")
+		cmd = exec.Command("hashdeep", "-l", "-r", "-a", "-k", "tests/hashdeep_both_symlinks.hashdeep", "/tmp/out")
 		out, err = cmd.CombinedOutput()
 		exitCode = 0
 		if msg, ok := err.(*exec.ExitError); ok { // there is error code

--- a/git.go
+++ b/git.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -116,7 +117,11 @@ func doMirrorOrUpdate(gitModule GitModule, workDir string, retryCount int) bool 
 	}
 
 	if needSSHKey {
-		er = executeCommand("ssh-agent bash -c 'ssh-add "+gitModule.privateKey+"; "+gitCmd+"'", config.Timeout, gitModule.ignoreUnreachable)
+		sshAddCmd := "ssh-add "
+		if runtime.GOOS == "darwin" {
+			sshAddCmd = "ssh-add -K "
+		}
+		er = executeCommand("ssh-agent bash -c '"+sshAddCmd+gitModule.privateKey+"; "+gitCmd+"'", config.Timeout, gitModule.ignoreUnreachable)
 	} else {
 		er = executeCommand(gitCmd, config.Timeout, gitModule.ignoreUnreachable)
 	}


### PR DESCRIPTION
The command ssh-add without -K will always generate a password prompt for each git repository. To avoid it you should use -K. So ssh-add will use OS X Keychain