### PR TITLE
add module parameter :use_ssh_agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,19 @@ Synced ./Puppetfile with 4 git repositories and 0 Forge modules in 1.1s with git
 
 Now also supports the r10k setting name `:default_branch => 'master'` See [#73](https://github.com/xorpaul/g10k/issues/73)
 
+- additionl Git attribute `:use_ssh_agent`:
+
+Normally g10k adds the SSH key specified in the g10k config for each SSH+Git module in your Puppetfile.
+If you don't want to use this SSH key, need a different key for a certain Git module or have the key encrypted in your SSH agent, then use this parameter to skip the `ssh-add` commands:
+
+```
+mod 'example_module',
+  :git => 'git@somehost.com/foo/example-module.git',
+  :branch => 'foo',
+  :use_ssh_agent => true
+```
+See [#171](https://github.com/xorpaul/g10k/issues/171) for more details.
+
 - additional Forge attribute `:sha256sum`:
 
 For (some) increased security you can add a SHA256 sum for each Forge module, which g10k will verify after downloading the respective .tar.gz file:

--- a/config.go
+++ b/config.go
@@ -196,7 +196,7 @@ func readPuppetfile(pf string, sshKey string, source string, branch string, forc
 	reForgeModule := regexp.MustCompile("^\\s*(?:mod)\\s+['\"]?([^'\"]+[-/][^'\"]+)['\"](?:\\s*)[,]?(.*)")
 	reForgeAttribute := regexp.MustCompile("\\s*['\"]?([^\\s'\"]+)\\s*['\"]?(?:=>)?\\s*['\"]?([^'\"]+)?")
 	reGitModule := regexp.MustCompile("^\\s*(?:mod)\\s+['\"]?([^'\"/]+)['\"]\\s*,(.*)")
-	reGitAttribute := regexp.MustCompile("\\s*:(git|commit|tag|branch|ref|link|ignore[-_]unreachable|fallback|install_path|default_branch|local)\\s*=>\\s*['\"]?([^'\"]+)['\"]?")
+	reGitAttribute := regexp.MustCompile("\\s*:(git|commit|tag|branch|ref|link|ignore[-_]unreachable|fallback|install_path|default_branch|local|use_ssh_agent)\\s*=>\\s*['\"]?([^'\"]+)['\"]?")
 	reUniqueGitAttribute := regexp.MustCompile("\\s*:(?:commit|tag|branch|ref|link)\\s*=>")
 	reDanglingAttribute := regexp.MustCompile("^\\s*:[^ ]+\\s*=>")
 	moduleDir := "modules"
@@ -392,6 +392,12 @@ func readPuppetfile(pf string, sshKey string, source string, branch string, forc
 						if local {
 							gm.local = true
 						}
+					} else if gitModuleAttribute == "use_ssh_agent" {
+						useSSHAgent, err := strconv.ParseBool(a[2])
+						if err != nil {
+							Fatalf("Error: Can not convert value " + a[2] + " of parameter " + gitModuleAttribute + " to boolean. In " + pf + " for module " + gitModuleName + " line: " + line)
+						}
+						gm.useSSHAgent = useSSHAgent
 					}
 
 				}

--- a/g10k.go
+++ b/g10k.go
@@ -182,6 +182,7 @@ type GitModule struct {
 	installPath       string
 	local             bool
 	moduleDir         string
+	useSSHAgent       bool
 }
 
 // ForgeResult is returned by queryForgeAPI and contains if and which version of the Puppetlabs Forge module needs to be downloaded

--- a/g10k_puppetfile_test.go
+++ b/g10k_puppetfile_test.go
@@ -98,7 +98,9 @@ func equalGitModule(a, b GitModule) bool {
 		a.ref != b.ref ||
 		a.link != b.link ||
 		a.ignoreUnreachable != b.ignoreUnreachable ||
-		a.installPath != b.installPath {
+		a.installPath != b.installPath ||
+		a.local != b.local ||
+		a.useSSHAgent != b.useSSHAgent {
 		return false
 	}
 	if len(a.fallback) != len(b.fallback) {
@@ -496,6 +498,27 @@ func TestReadPuppetfileGitDashNSlashNotation(t *testing.T) {
 
 	if !equalPuppetfile(got, expected) {
 		spew.Dump(expected)
+		spew.Dump(got)
+		t.Errorf("Expected Puppetfile: %+v, but got Puppetfile: %+v", expected, got)
+	}
+}
+
+func TestReadPuppetfileSSHKeyAlreadyLoaded(t *testing.T) {
+	quiet = true
+	funcName := strings.Split(funcName(), ".")[len(strings.Split(funcName(), "."))-1]
+	got := readPuppetfile("tests/"+funcName, "", "test", "test", false, false)
+
+	fm := make(map[string]ForgeModule)
+	gm := make(map[string]GitModule)
+	gm["example_module"] = GitModule{git: "git@somehost.com/foo/example-module.git", branch: "foo", useSSHAgent: true}
+
+	expected := Puppetfile{source: "test", gitModules: gm, forgeModules: fm}
+	//fmt.Println(got)
+
+	if !equalPuppetfile(got, expected) {
+		fmt.Println("Expected:")
+		spew.Dump(expected)
+		fmt.Println("Got:")
 		spew.Dump(got)
 		t.Errorf("Expected Puppetfile: %+v, but got Puppetfile: %+v", expected, got)
 	}

--- a/tests/TestConfigUseSSHAgent.yaml
+++ b/tests/TestConfigUseSSHAgent.yaml
@@ -1,0 +1,8 @@
+---
+:cachedir: '/tmp/g10k'
+
+sources:
+  example:
+    remote: 'https://github.com/xorpaul/g10k-environment.git'
+    basedir: '/tmp/example/'
+    private_key: 'tests/TestConfigUseSSHAgent.yaml' # just some existing file, we just want to check if the ssh-add command isn't used

--- a/tests/TestReadPuppetfileSSHKeyAlreadyLoaded
+++ b/tests/TestReadPuppetfileSSHKeyAlreadyLoaded
@@ -1,0 +1,5 @@
+mod 'example_module',
+  :git => 'git@somehost.com/foo/example-module.git',
+  :branch => 'foo',
+  :use_ssh_agent => true
+


### PR DESCRIPTION
This parameter can be used to skip `ssh-add` commands before git over SSH commands, fixes #171