### PR TITLE
fix: Fix logic of useSSHAgent and needSSHKey

### DIFF
--- a/git.go
+++ b/git.go
@@ -101,11 +101,11 @@ func doMirrorOrUpdate(gitModule GitModule, workDir string, retryCount int) bool 
 	isInModulesCacheDir := strings.HasPrefix(workDir, config.ModulesCacheDir)
 
 	needSSHKey := true
-	if len(gitModule.privateKey) == 0 || strings.Contains(gitModule.git, "github.com") || gitModule.useSSHAgent == true {
+	if len(gitModule.privateKey) == 0 || strings.Contains(gitModule.git, "github.com") || gitModule.useSSHAgent == false {
 		if isControlRepo {
-			needSSHKey = true
-		} else {
 			needSSHKey = false
+		} else {
+			needSSHKey = true
 		}
 	}
 	er := ExecResult{}


### PR DESCRIPTION
* Fix logic of useSSHAgent and needSSHKey

For us the fix in https://github.com/xorpaul/g10k/issues/171 did not work. g10k still asks for passwords with two different types of diaglogs. We fiddled around with the useSSHAgent and needSSHKey and this change works for us but i am not a go programmer and i don't know if it still works for the opposite usecase. Can you please take a lookg @xorpaul ?