### PR TITLE
Add support for strip_component

### DIFF
--- a/forge.go
+++ b/forge.go
@@ -336,7 +336,7 @@ func extractForgeModule(wgForgeModule *sync.WaitGroup, file *io.PipeReader, file
 	before := time.Now()
 	fileReader, err := pgzip.NewReader(file)
 
-	unTar(fileReader, config.ForgeCacheDir)
+	unTar(fileReader, config.ForgeCacheDir, "")
 
 	if err != nil {
 		Fatalf(funcName + "(): pgzip reader error for module " + fileName + " error:" + err.Error())

--- a/g10k.go
+++ b/g10k.go
@@ -134,6 +134,7 @@ type Source struct {
 	AutoCorrectEnvironmentNames string `yaml:"invalid_branches"`
 	FilterCommand               string `yaml:"filter_command"`
 	FilterRegex                 string `yaml:"filter_regex"`
+	StripComponent              string `yaml:"strip_component"`
 }
 
 // Puppetfile contains the key value pairs from the Puppetfile
@@ -182,6 +183,7 @@ type GitModule struct {
 	local             bool
 	moduleDir         string
 	useSSHAgent       bool
+	stripComponent    string
 }
 
 // ForgeResult is returned by queryForgeAPI and contains if and which version of the Puppetlabs Forge module needs to be downloaded

--- a/git.go
+++ b/git.go
@@ -264,7 +264,7 @@ func syncToModuleDir(gitModule GitModule, srcDir string, targetDir string, corre
 			cmd.Start()
 
 			before := time.Now()
-			unTar(cmdOut, targetDir)
+			unTar(cmdOut, targetDir, gitModule.stripComponent)
 			duration := time.Since(before).Seconds()
 			mutex.Lock()
 			ioGitTime += duration

--- a/modules.go
+++ b/modules.go
@@ -6,10 +6,19 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
-func unTar(r io.Reader, targetBaseDir string) {
+func strip(component string, value string) string {
+	if regexp.MustCompile(`^/.*/$`).MatchString(component) {
+		return regexp.MustCompile(component[1:len(component)-1]).ReplaceAllString(value, "")
+	} else {
+		return strings.TrimPrefix(value, component)
+	}
+}
+
+func unTar(r io.Reader, targetBaseDir string, stripComponent string) {
 	funcName := funcName()
 	tarBallReader := tar.NewReader(r)
 	for {
@@ -37,7 +46,7 @@ func unTar(r io.Reader, targetBaseDir string) {
 		if matchSkiplistContent(skiplistFilename) {
 			continue
 		}
-		targetFilename := filepath.Join(targetBaseDir, filename)
+		targetFilename := filepath.Join(targetBaseDir, strip(stripComponent, filename))
 
 		switch header.Typeflag {
 		case tar.TypeDir:

--- a/puppetfile.go
+++ b/puppetfile.go
@@ -150,6 +150,7 @@ func resolvePuppetEnvironment(tags bool, outputNameTag string) {
 							if len(moduleParam) == 0 {
 								gitModule := GitModule{}
 								gitModule.tree = branch
+								gitModule.stripComponent = sa.StripComponent
 								syncToModuleDir(gitModule, workDir, targetDir, env)
 							}
 							pf := filepath.Join(targetDir, "Puppetfile")


### PR DESCRIPTION
r10k supports a source configuration option `strip_component`: https://github.com/puppetlabs/r10k/blob/main/doc/dynamic-environments/configuration.mkd#strip_component

This adds similar support to g10k.