### PR TITLE
cache forge modules under its own cache directory in puppetfile mode

### DIFF
--- a/g10k.go
+++ b/g10k.go
@@ -309,9 +309,10 @@ func main() {
 				cachedir = checkDirAndCreate(cachedir, "cachedir default value")
 			}
 			// default purge_levels
-			modulesCacheDir := filepath.Join(cachedir, "modules")
-			envsCacheDir := filepath.Join(cachedir, "environments")
-			config = ConfigSettings{CacheDir: cachedir, ForgeCacheDir: cachedir, ModulesCacheDir: modulesCacheDir, EnvCacheDir: envsCacheDir, Sources: sm, ForgeBaseURL: "https://forgeapi.puppet.com", Maxworker: maxworker, UseCacheFallback: usecacheFallback, MaxExtractworker: maxExtractworker, RetryGitCommands: retryGitCommands, GitObjectSyntaxNotSupported: gitObjectSyntaxNotSupported}
+			forgeCachedir := checkDirAndCreate(filepath.Join(cachedir, "forge"), "/tmp/g10k/forge")
+			modulesCacheDir := checkDirAndCreate(filepath.Join(cachedir, "modules"), "/tmp/g10k/modules")
+			envsCacheDir := checkDirAndCreate(filepath.Join(cachedir, "environments"), "/tmp/g10k/environments")
+			config = ConfigSettings{CacheDir: cachedir, ForgeCacheDir: forgeCachedir, ModulesCacheDir: modulesCacheDir, EnvCacheDir: envsCacheDir, Sources: sm, ForgeBaseURL: "https://forgeapi.puppet.com", Maxworker: maxworker, UseCacheFallback: usecacheFallback, MaxExtractworker: maxExtractworker, RetryGitCommands: retryGitCommands, GitObjectSyntaxNotSupported: gitObjectSyntaxNotSupported}
 			config.PurgeLevels = []string{"puppetfile"}
 			target = pfLocation
 			puppetfile := readPuppetfile(target, "", "cmdlineparam", "cmdlineparam", false, false)


### PR DESCRIPTION
Modules from puppet forge were being stored directly under cache directory instead of `forge` subdirectory in cache.

This was a difference in behaviour between `config` and `puppetfile` modes and causing forge modules to be stored 2x in cache.